### PR TITLE
Add isSecure for RaoResult

### DIFF
--- a/data/crac/crac-api/src/main/java/com/powsybl/openrao/data/cracapi/Crac.java
+++ b/data/crac/crac-api/src/main/java/com/powsybl/openrao/data/cracapi/Crac.java
@@ -112,11 +112,6 @@ public interface Crac extends Identifiable<Crac> {
     Instant getLastInstant();
 
     /**
-     * Gather all the instants before given instant, this one included.
-     */
-    Set<Instant> getInstantsBefore(Instant instant);
-
-    /**
      * Returns whether a crac has an auto instant
      */
     boolean hasAutoInstant();

--- a/data/crac/crac-api/src/main/java/com/powsybl/openrao/data/cracapi/Crac.java
+++ b/data/crac/crac-api/src/main/java/com/powsybl/openrao/data/cracapi/Crac.java
@@ -107,6 +107,16 @@ public interface Crac extends Identifiable<Crac> {
     Instant getOutageInstant();
 
     /**
+     * Return the last instant, i.e. the only instant that has no instant after it
+     */
+    Instant getLastInstant();
+
+    /**
+     * Gather all the instants before given instant, this one included.
+     */
+    Set<Instant> getInstantsBefore(Instant instant);
+
+    /**
      * Returns whether a crac has an auto instant
      */
     boolean hasAutoInstant();

--- a/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/CracImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/CracImpl.java
@@ -228,11 +228,6 @@ public class CracImpl extends AbstractIdentifiable<Crac> implements Crac {
     }
 
     @Override
-    public Set<Instant> getInstantsBefore(Instant instant) {
-        return instants.values().stream().filter(otherInstant -> otherInstant.equals(instant) || otherInstant.comesBefore(instant)).collect(Collectors.toSet());
-    }
-
-    @Override
     public boolean hasAutoInstant() {
         return !getInstants(InstantKind.AUTO).isEmpty();
     }

--- a/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/CracImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/CracImpl.java
@@ -223,6 +223,16 @@ public class CracImpl extends AbstractIdentifiable<Crac> implements Crac {
     }
 
     @Override
+    public Instant getLastInstant() {
+        return lastInstantAdded;
+    }
+
+    @Override
+    public Set<Instant> getInstantsBefore(Instant instant) {
+        return instants.values().stream().filter(otherInstant -> otherInstant.equals(instant) || otherInstant.comesBefore(instant)).collect(Collectors.toSet());
+    }
+
+    @Override
     public boolean hasAutoInstant() {
         return !getInstants(InstantKind.AUTO).isEmpty();
     }

--- a/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/CracImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/CracImplTest.java
@@ -927,6 +927,33 @@ class CracImplTest {
     }
 
     @Test
+    void testGetLastInstant() {
+        assertEquals(curativeInstant, crac.getLastInstant());
+    }
+
+    @Test
+    void testGetLastInstantWithMultipleInstantsPerInstantKind() {
+        crac.newInstant("curative 2", InstantKind.CURATIVE)
+            .newInstant("curative 3", InstantKind.CURATIVE);
+        Instant curativeInstant3 = crac.getInstant("curative 3");
+        assertEquals(curativeInstant3, crac.getLastInstant());
+    }
+
+    @Test
+    void testGetInstantBefore() {
+        assertEquals(Set.of(preventiveInstant, outageInstant, autoInstant), crac.getInstantsBefore(autoInstant));
+    }
+
+    @Test
+    void testGetInstantBeforeWithMultipleInstantsPerInstantKind() {
+        crac.newInstant("curative 2", InstantKind.CURATIVE)
+            .newInstant("curative 3", InstantKind.CURATIVE)
+            .newInstant("curative 4", InstantKind.CURATIVE);
+        Instant curativeInstant2 = crac.getInstant("curative 2");
+        assertEquals(Set.of(preventiveInstant, outageInstant, autoInstant, curativeInstant, curativeInstant2), crac.getInstantsBefore(curativeInstant2));
+    }
+
+    @Test
     void testGetInstantsByKindWithTwoInstantsPerInstantKind() {
         crac.newInstant("preventive 2", InstantKind.PREVENTIVE)
             .newInstant("outage 2", InstantKind.OUTAGE)

--- a/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/CracImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/CracImplTest.java
@@ -940,20 +940,6 @@ class CracImplTest {
     }
 
     @Test
-    void testGetInstantBefore() {
-        assertEquals(Set.of(preventiveInstant, outageInstant, autoInstant), crac.getInstantsBefore(autoInstant));
-    }
-
-    @Test
-    void testGetInstantBeforeWithMultipleInstantsPerInstantKind() {
-        crac.newInstant("curative 2", InstantKind.CURATIVE)
-            .newInstant("curative 3", InstantKind.CURATIVE)
-            .newInstant("curative 4", InstantKind.CURATIVE);
-        Instant curativeInstant2 = crac.getInstant("curative 2");
-        assertEquals(Set.of(preventiveInstant, outageInstant, autoInstant, curativeInstant, curativeInstant2), crac.getInstantsBefore(curativeInstant2));
-    }
-
-    @Test
     void testGetInstantsByKindWithTwoInstantsPerInstantKind() {
         crac.newInstant("preventive 2", InstantKind.PREVENTIVE)
             .newInstant("outage 2", InstantKind.OUTAGE)

--- a/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
+++ b/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
@@ -413,4 +413,11 @@ public interface RaoResult {
      * @return whether all the CNECs of the given type(s) are secure at the optimized instant or not.
      */
     boolean isSecure(Instant optimizedInstant, PhysicalParameter... u);
+
+    /**
+     * Indicates whether all the CNECs are secure.
+     *
+     * @return whether all the CNECs are secure or not.
+     */
+    boolean isSecure();
 }

--- a/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
+++ b/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
@@ -410,22 +410,22 @@ public interface RaoResult {
      *
      * @param optimizedInstant: The instant to assess
      * @param u: The types of CNECs to check (FLOW -> FlowCNECs, ANGLE -> AngleCNECs, VOLTAGE -> VoltageCNECs). 1 to 3 arguments can be provided.
-     * @return whether all the CNECs of the given type(s) are secure at the optimized instant or not.
+     * @return whether all the CNECs of the given type(s) are secure at the optimized instant.
      */
     boolean isSecure(Instant optimizedInstant, PhysicalParameter... u);
 
     /**
-     * Indicates whether all the CNECs of a given type are secure.
+     * Indicates whether all the CNECs of a given type are secure at last instant (i.e. after RAO)..
      *
      * @param u: The types of CNECs to check (FLOW -> FlowCNECs, ANGLE -> AngleCNECs, VOLTAGE -> VoltageCNECs). 1 to 3 arguments can be provided.
-     * @return whether all the CNECs of the given type(s) are secure at the last instant.
+     * @return whether all the CNECs of the given type(s) are secure at last instant (i.e. after RAO)..
      */
     boolean isSecure(PhysicalParameter... u);
 
     /**
-     * Indicates whether all the CNECs are secure at last instant.
+     * Indicates whether all the CNECs are secure at last instant (i.e. after RAO)..
      *
-     * @return whether all the CNECs are secure at last instant or not.
+     * @return whether all the CNECs are secure at last instant (i.e. after RAO)..
      */
     default boolean isSecure() {
         return isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE);

--- a/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
+++ b/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.data.raoresultapi;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.Crac;
 import com.powsybl.openrao.data.cracapi.Instant;
@@ -403,4 +404,13 @@ public interface RaoResult {
     OptimizationStepsExecuted getOptimizationStepsExecuted();
 
     void setOptimizationStepsExecuted(OptimizationStepsExecuted optimizationStepsExecuted);
+
+    /**
+     * Indicates whether the all the CNECs of a given type at a given instant are secure.
+     *
+     * @param optimizedInstant: The instant to assess
+     * @param u: The types of CNECs to check (FLOW -> FlowCNECs, ANGLE -> AngleCNECs, VOLTAGE -> VoltageCNECs). 1 to 3 arguments can be provided.
+     * @return whether all the CNECs of the given type(s) are secure at the optimized instant or not.
+     */
+    boolean isSecure(Instant optimizedInstant, PhysicalParameter... u);
 }

--- a/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
+++ b/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResult.java
@@ -415,9 +415,19 @@ public interface RaoResult {
     boolean isSecure(Instant optimizedInstant, PhysicalParameter... u);
 
     /**
-     * Indicates whether all the CNECs are secure.
+     * Indicates whether all the CNECs of a given type are secure.
      *
-     * @return whether all the CNECs are secure or not.
+     * @param u: The types of CNECs to check (FLOW -> FlowCNECs, ANGLE -> AngleCNECs, VOLTAGE -> VoltageCNECs). 1 to 3 arguments can be provided.
+     * @return whether all the CNECs of the given type(s) are secure at the last instant.
      */
-    boolean isSecure();
+    boolean isSecure(PhysicalParameter... u);
+
+    /**
+     * Indicates whether all the CNECs are secure at last instant.
+     *
+     * @return whether all the CNECs are secure at last instant or not.
+     */
+    default boolean isSecure() {
+        return isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE);
+    }
 }

--- a/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResultClone.java
+++ b/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResultClone.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.data.raoresultapi;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.RemedialAction;
@@ -163,6 +164,11 @@ public class RaoResultClone implements RaoResult {
     @Override
     public void setOptimizationStepsExecuted(OptimizationStepsExecuted optimizationStepsExecuted) {
         raoResult.setOptimizationStepsExecuted(optimizationStepsExecuted);
+    }
+
+    @Override
+    public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
+        return raoResult.isSecure(optimizedInstant, u);
     }
 
     @Override

--- a/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResultClone.java
+++ b/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResultClone.java
@@ -172,6 +172,11 @@ public class RaoResultClone implements RaoResult {
     }
 
     @Override
+    public boolean isSecure(PhysicalParameter... u) {
+        return raoResult.isSecure(u);
+    }
+
+    @Override
     public boolean isSecure() {
         return raoResult.isSecure();
     }

--- a/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResultClone.java
+++ b/data/rao-result/rao-result-api/src/main/java/com/powsybl/openrao/data/raoresultapi/RaoResultClone.java
@@ -172,6 +172,11 @@ public class RaoResultClone implements RaoResult {
     }
 
     @Override
+    public boolean isSecure() {
+        return raoResult.isSecure();
+    }
+
+    @Override
     public OptimizationStepsExecuted getOptimizationStepsExecuted() {
         return raoResult.getOptimizationStepsExecuted();
     }

--- a/data/rao-result/rao-result-api/src/test/java/com/powsybl/openrao/data/raoresultapi/RaoResultCloneTest.java
+++ b/data/rao-result/rao-result-api/src/test/java/com/powsybl/openrao/data/raoresultapi/RaoResultCloneTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.openrao.data.raoresultapi;
 
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.data.cracapi.Crac;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.State;
@@ -191,6 +192,11 @@ class RaoResultCloneTest {
         when(raoResult.getComputationStatus(crac.getPreventiveState())).thenReturn(ComputationStatus.DEFAULT);
         when(raoResult.getComputationStatus(crac.getState("contingency1Id", curativeInstant))).thenReturn(ComputationStatus.FAILURE);
         when(raoResult.getComputationStatus(crac.getState("contingency2Id", autoInstant))).thenReturn(ComputationStatus.DEFAULT);
+
+        when(raoResult.isSecure()).thenReturn(false);
+        when(raoResult.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE)).thenReturn(true);
+        when(raoResult.isSecure(PhysicalParameter.VOLTAGE)).thenReturn(false);
+        when(raoResult.isSecure(any(Instant.class), eq(PhysicalParameter.VOLTAGE))).thenReturn(false);
 
         testRaoResultClone(new RaoResultClone(raoResult), crac);
 
@@ -407,5 +413,10 @@ class RaoResultCloneTest {
         assertEquals(ComputationStatus.DEFAULT, raoResultClone.getComputationStatus(crac.getPreventiveState()));
         assertEquals(ComputationStatus.FAILURE, raoResultClone.getComputationStatus(crac.getState("contingency1Id", curativeInstant)));
         assertEquals(ComputationStatus.DEFAULT, raoResultClone.getComputationStatus(crac.getState("contingency2Id", autoInstant)));
+
+        assertFalse(raoResultClone.isSecure());
+        assertTrue(raoResultClone.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertFalse(raoResultClone.isSecure(PhysicalParameter.VOLTAGE));
+        assertFalse(raoResultClone.isSecure(curativeInstant, PhysicalParameter.VOLTAGE));
     }
 }

--- a/data/rao-result/rao-result-impl/src/main/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImpl.java
+++ b/data/rao-result/rao-result-impl/src/main/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImpl.java
@@ -340,30 +340,27 @@ public class RaoResultImpl implements RaoResult {
         }
     }
 
-    private boolean instantHasAnyNegativeMargin(Instant instant, PhysicalParameter... u) {
+    private boolean instantHasNoNegativeMargin(Instant optimizedInstant, PhysicalParameter... u) {
         for (PhysicalParameter physicalParameter : Set.of(u)) {
             switch (physicalParameter) {
                 case ANGLE -> {
-                    if (angleCnecResults.keySet().stream()
-                            .anyMatch(angleCnec -> getMargin(instant, angleCnec, Unit.DEGREE) < 0)) {
-                        return true;
+                    if (angleCnecResults.keySet().stream().anyMatch(cnec -> getMargin(optimizedInstant, cnec, Unit.DEGREE) < 0)) {
+                        return false;
                     }
                 }
                 case FLOW -> {
-                    if (flowCnecResults.keySet().stream()
-                            .anyMatch(flowCnec -> getMargin(instant, flowCnec, Unit.MEGAWATT) < 0)) {
-                        return true;
+                    if (flowCnecResults.keySet().stream().anyMatch(cnec -> getMargin(optimizedInstant, cnec, Unit.MEGAWATT) < 0)) {
+                        return false;
                     }
                 }
                 case VOLTAGE -> {
-                    if (voltageCnecResults.keySet().stream()
-                            .anyMatch(voltageCnec -> getMargin(instant, voltageCnec, Unit.KILOVOLT) < 0)) {
-                        return true;
+                    if (voltageCnecResults.keySet().stream().anyMatch(cnec -> getMargin(optimizedInstant, cnec, Unit.KILOVOLT) < 0)) {
+                        return false;
                     }
                 }
             }
         }
-        return false;
+        return true;
     }
 
     @Override
@@ -371,17 +368,12 @@ public class RaoResultImpl implements RaoResult {
         if (ComputationStatus.FAILURE.equals(getComputationStatus())) {
             return false;
         }
-        for (Instant instant : crac.getInstantsBefore(optimizedInstant)) {
-            if (instantHasAnyNegativeMargin(instant, u)) {
-                return false;
-            }
-        }
-        return true;
+        return instantHasNoNegativeMargin(optimizedInstant, u);
     }
 
     @Override
-    public boolean isSecure() {
-        return isSecure(crac.getLastInstant(), PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE);
+    public boolean isSecure(PhysicalParameter... u) {
+        return isSecure(crac.getLastInstant(), u);
     }
 
     @Override

--- a/data/rao-result/rao-result-impl/src/main/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImpl.java
+++ b/data/rao-result/rao-result-impl/src/main/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImpl.java
@@ -7,6 +7,7 @@
 package com.powsybl.openrao.data.raoresultimpl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.*;
 import com.powsybl.openrao.data.cracapi.cnec.AngleCnec;
@@ -337,6 +338,29 @@ public class RaoResultImpl implements RaoResult {
         } else {
             throw new OpenRaoException("The RaoResult object should not be modified outside of its usual routine");
         }
+    }
+
+    @Override
+    public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
+        for (PhysicalParameter physicalParameter : Set.of(u)) {
+            if (PhysicalParameter.FLOW.equals(physicalParameter)) {
+                boolean unsecureFlowCnec = !flowCnecResults.values().stream().filter(result -> result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.MEGAWATT) < 0).toList().isEmpty();
+                if (unsecureFlowCnec) {
+                    return false;
+                }
+            } else if (PhysicalParameter.ANGLE.equals(physicalParameter)) {
+                boolean unsecureAngleCnec = !angleCnecResults.values().stream().filter(result -> result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.DEGREE) < 0).toList().isEmpty();
+                if (unsecureAngleCnec) {
+                    return false;
+                }
+            } else {
+                boolean unsecureVoltageCnec = !voltageCnecResults.values().stream().filter(result -> result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.KILOVOLT) < 0).toList().isEmpty();
+                if (unsecureVoltageCnec) {
+                    return false;
+                }
+            }
+        }
+        return true;
     }
 
     @Override

--- a/data/rao-result/rao-result-impl/src/main/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImpl.java
+++ b/data/rao-result/rao-result-impl/src/main/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImpl.java
@@ -343,20 +343,24 @@ public class RaoResultImpl implements RaoResult {
     @Override
     public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
         for (PhysicalParameter physicalParameter : Set.of(u)) {
-            if (PhysicalParameter.FLOW.equals(physicalParameter)) {
-                boolean unsecureFlowCnec = !flowCnecResults.values().stream().filter(result -> result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.MEGAWATT) < 0).toList().isEmpty();
-                if (unsecureFlowCnec) {
-                    return false;
+            switch (physicalParameter) {
+                case ANGLE -> {
+                    if (!angleCnecResults.values().stream().filter(result ->
+                            result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.DEGREE) < 0).toList().isEmpty()) {
+                        return false;
+                    }
                 }
-            } else if (PhysicalParameter.ANGLE.equals(physicalParameter)) {
-                boolean unsecureAngleCnec = !angleCnecResults.values().stream().filter(result -> result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.DEGREE) < 0).toList().isEmpty();
-                if (unsecureAngleCnec) {
-                    return false;
+                case FLOW -> {
+                    if (!flowCnecResults.values().stream().filter(result ->
+                            result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.MEGAWATT) < 0).toList().isEmpty()) {
+                        return false;
+                    }
                 }
-            } else {
-                boolean unsecureVoltageCnec = !voltageCnecResults.values().stream().filter(result -> result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.KILOVOLT) < 0).toList().isEmpty();
-                if (unsecureVoltageCnec) {
-                    return false;
+                case VOLTAGE -> {
+                    if (!voltageCnecResults.values().stream().filter(result ->
+                            result.getResult(optimizedInstant) != null && result.getResult(optimizedInstant).getMargin(Unit.KILOVOLT) < 0).toList().isEmpty()) {
+                        return false;
+                    }
                 }
             }
         }

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/FlowCnecResultTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/FlowCnecResultTest.java
@@ -11,6 +11,8 @@ import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.cnec.Side;
 import org.junit.jupiter.api.Test;
 
+import java.lang.reflect.InvocationTargetException;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -33,7 +35,7 @@ class FlowCnecResultTest {
     }
 
     @Test
-    void testGetAndCreateIfAbsent() {
+    void testGetAndCreateIfAbsent() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         FlowCnecResult flowCnecResult = new FlowCnecResult();
         assertEquals(Double.NaN, flowCnecResult.getResult(null).getFlow(Side.LEFT, Unit.MEGAWATT));
         assertEquals(Double.NaN, flowCnecResult.getResult(null).getFlow(Side.RIGHT, Unit.MEGAWATT));

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/FlowCnecResultTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/FlowCnecResultTest.java
@@ -11,8 +11,6 @@ import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.cnec.Side;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.InvocationTargetException;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 
@@ -35,7 +33,7 @@ class FlowCnecResultTest {
     }
 
     @Test
-    void testGetAndCreateIfAbsent() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+    void testGetAndCreateIfAbsent() {
         FlowCnecResult flowCnecResult = new FlowCnecResult();
         assertEquals(Double.NaN, flowCnecResult.getResult(null).getFlow(Side.LEFT, Unit.MEGAWATT));
         assertEquals(Double.NaN, flowCnecResult.getResult(null).getFlow(Side.RIGHT, Unit.MEGAWATT));

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
@@ -271,7 +271,18 @@ class RaoResultImplTest {
     }
 
     @Test
-    void testIsNotSecureCheckPhysicalParameterKind() {
+    void testIsSecureUnlessSomeNegativeMarginOnCnecResult() {
+        setUp();
+        assertTrue(raoResult.isSecure());
+        FlowCnecResult result = raoResult.getAndCreateIfAbsentFlowCnecResult(cnec);
+        ElementaryFlowCnecResult elementaryFlowCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(preventiveInstant);
+        elementaryFlowCnecResult.setFlow(Side.LEFT, 505., MEGAWATT);
+        elementaryFlowCnecResult.setMargin(-5., MEGAWATT);
+        assertFalse(raoResult.isSecure());
+    }
+
+    @Test
+    void testIsNotSecureCheckPhysicalParameterKind2() {
         setUp();
         AngleCnec angleCnec = crac.newAngleCnec()
                 .withId("AngleCnec")

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
@@ -295,7 +295,7 @@ class RaoResultImplTest {
     }
 
     @Test
-    void testIsSecureIfBeforeUnsecureInstant() {
+    void testIsSecureDependsOnOptimizationState() {
         setUp();
         VoltageCnec voltageCnec = crac.newVoltageCnec()
                 .withId("VoltageCnec")
@@ -310,11 +310,17 @@ class RaoResultImplTest {
                 .add();
 
         VoltageCnecResult result = raoResult.getAndCreateIfAbsentVoltageCnecResult(voltageCnec);
-        ElementaryVoltageCnecResult elementaryVoltageCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(autoInstant);
+        ElementaryVoltageCnecResult elementaryVoltageCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(preventiveInstant);
+        elementaryVoltageCnecResult.setVoltage(200., KILOVOLT);
+        elementaryVoltageCnecResult.setMargin(20., KILOVOLT);
+        elementaryVoltageCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(autoInstant);
         elementaryVoltageCnecResult.setVoltage(175., KILOVOLT);
         elementaryVoltageCnecResult.setMargin(-5., KILOVOLT);
+        elementaryVoltageCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(curativeInstant);
+        elementaryVoltageCnecResult.setVoltage(200., KILOVOLT);
+        elementaryVoltageCnecResult.setMargin(20., KILOVOLT);
         assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
         assertFalse(raoResult.isSecure(autoInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
-        assertFalse(raoResult.isSecure(curativeInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
+        assertTrue(raoResult.isSecure(curativeInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
     }
 }

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
@@ -11,8 +11,10 @@ import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.data.cracapi.Crac;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.State;
+import com.powsybl.openrao.data.cracapi.cnec.AngleCnec;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
 import com.powsybl.openrao.data.cracapi.cnec.Side;
+import com.powsybl.openrao.data.cracapi.cnec.VoltageCnec;
 import com.powsybl.openrao.data.cracapi.networkaction.ActionType;
 import com.powsybl.openrao.data.cracapi.networkaction.NetworkAction;
 import com.powsybl.openrao.data.cracapi.rangeaction.PstRangeAction;
@@ -26,8 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 import java.util.Set;
 
-import static com.powsybl.openrao.commons.Unit.AMPERE;
-import static com.powsybl.openrao.commons.Unit.MEGAWATT;
+import static com.powsybl.openrao.commons.Unit.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -254,5 +255,66 @@ class RaoResultImplTest {
         assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
         assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
         assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
+    }
+
+    @Test
+    void testIsNotSecureIfComputationStatusIsFailure() {
+        setUp();
+        raoResult.setComputationStatus(ComputationStatus.FAILURE);
+        assertFalse(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW));
+    }
+
+    @Test
+    void testIsSecureIfNoCnecOfGivenParameterType() {
+        setUp();
+        assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.ANGLE));
+    }
+
+    @Test
+    void testIsNotSecureCheckPhysicalParameterKind() {
+        setUp();
+        AngleCnec angleCnec = crac.newAngleCnec()
+                .withId("AngleCnec")
+                .withInstant(AUTO_INSTANT_ID)
+                .withExportingNetworkElement("ExportingNE")
+                .withImportingNetworkElement("ImportingNE")
+                .withContingency("Contingency FR1 FR3")
+                .newThreshold()
+                .withMin(0.)
+                .withMax(30.)
+                .withUnit(DEGREE)
+                .add()
+                .add();
+
+        AngleCnecResult result = raoResult.getAndCreateIfAbsentAngleCnecResult(angleCnec);
+        ElementaryAngleCnecResult elementaryAngleCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(autoInstant);
+        elementaryAngleCnecResult.setAngle(35., DEGREE);
+        elementaryAngleCnecResult.setMargin(-5., DEGREE);
+        assertTrue(raoResult.isSecure(autoInstant, PhysicalParameter.FLOW));
+        assertFalse(raoResult.isSecure(autoInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+    }
+
+    @Test
+    void testIsSecureIfBeforeUnsecureInstant() {
+        setUp();
+        VoltageCnec voltageCnec = crac.newVoltageCnec()
+                .withId("VoltageCnec")
+                .withInstant(AUTO_INSTANT_ID)
+                .withNetworkElement("NetworkElement")
+                .withContingency("Contingency FR1 FR3")
+                .newThreshold()
+                .withMin(180.)
+                .withMax(250.)
+                .withUnit(KILOVOLT)
+                .add()
+                .add();
+
+        VoltageCnecResult result = raoResult.getAndCreateIfAbsentVoltageCnecResult(voltageCnec);
+        ElementaryVoltageCnecResult elementaryVoltageCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(autoInstant);
+        elementaryVoltageCnecResult.setVoltage(175., KILOVOLT);
+        elementaryVoltageCnecResult.setMargin(-5., KILOVOLT);
+        assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
+        assertFalse(raoResult.isSecure(autoInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
+        assertFalse(raoResult.isSecure(curativeInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
     }
 }

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
@@ -322,5 +322,6 @@ class RaoResultImplTest {
         assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
         assertFalse(raoResult.isSecure(autoInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
         assertTrue(raoResult.isSecure(curativeInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
+        assertTrue(raoResult.isSecure());
     }
 }

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
@@ -271,14 +271,11 @@ class RaoResultImplTest {
     }
 
     @Test
-    void testIsSecureUnlessSomeNegativeMarginOnCnecResult() {
+    void testIsSecureUnlessFunctionalCostPositive() {
         setUp();
-        assertTrue(raoResult.isSecure());
-        FlowCnecResult result = raoResult.getAndCreateIfAbsentFlowCnecResult(cnec);
-        ElementaryFlowCnecResult elementaryFlowCnecResult = result.getAndCreateIfAbsentResultForOptimizationState(preventiveInstant);
-        elementaryFlowCnecResult.setFlow(Side.LEFT, 505., MEGAWATT);
-        elementaryFlowCnecResult.setMargin(-5., MEGAWATT);
-        assertFalse(raoResult.isSecure());
+        assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW));
+        raoResult.getAndCreateIfAbsentCostResult(preventiveInstant.getId()).setFunctionalCost(10);
+        assertFalse(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW));
     }
 
     @Test

--- a/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
+++ b/data/rao-result/rao-result-impl/src/test/java/com/powsybl/openrao/data/raoresultimpl/RaoResultImplTest.java
@@ -7,6 +7,7 @@
 package com.powsybl.openrao.data.raoresultimpl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.data.cracapi.Crac;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.State;
@@ -242,5 +243,16 @@ class RaoResultImplTest {
         setUp();
         raoResult.setComputationStatus(crac.getState("Contingency FR1 FR3", autoInstant), ComputationStatus.DEFAULT);
         assertEquals(ComputationStatus.DEFAULT, raoResult.getComputationStatus(crac.getState("Contingency FR1 FR3", autoInstant)));
+    }
+
+    @Test
+    void testIsSecureFlowCnecs() {
+        setUp();
+        assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW));
+        assertTrue(raoResult.isSecure(autoInstant, PhysicalParameter.FLOW));
+        assertTrue(raoResult.isSecure(curativeInstant, PhysicalParameter.FLOW));
+        assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
+        assertTrue(raoResult.isSecure(preventiveInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
     }
 }

--- a/data/result-exporter/swe-cne-exporter/src/main/java/com/powsybl/openrao/data/swecneexporter/SweCne.java
+++ b/data/result-exporter/swe-cne-exporter/src/main/java/com/powsybl/openrao/data/swecneexporter/SweCne.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.data.swecneexporter;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.data.cneexportercommons.CneExporterParameters;
 import com.powsybl.openrao.data.cneexportercommons.CneUtil;
 import com.powsybl.openrao.data.cracapi.Crac;
@@ -108,7 +109,7 @@ public class SweCne {
         Reason reason = new Reason();
         RaoResult raoResult = sweCneHelper.getRaoResult();
         boolean isDivergent = sweCneHelper.isAnyContingencyInFailure() || raoResult.getComputationStatus() == ComputationStatus.FAILURE;
-        boolean isUnsecure = !raoResult.isSecure();
+        boolean isUnsecure = !raoResult.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE);
         if (isDivergent) {
             reason.setCode(DIVERGENCE_CODE);
             reason.setText(DIVERGENCE_TEXT);

--- a/data/result-exporter/swe-cne-exporter/src/main/java/com/powsybl/openrao/data/swecneexporter/SweCne.java
+++ b/data/result-exporter/swe-cne-exporter/src/main/java/com/powsybl/openrao/data/swecneexporter/SweCne.java
@@ -11,7 +11,6 @@ import com.powsybl.openrao.commons.OpenRaoException;
 import com.powsybl.openrao.data.cneexportercommons.CneExporterParameters;
 import com.powsybl.openrao.data.cneexportercommons.CneUtil;
 import com.powsybl.openrao.data.cracapi.Crac;
-import com.powsybl.openrao.data.cracapi.InstantKind;
 import com.powsybl.openrao.data.craccreation.creator.cim.craccreator.CimCracCreationContext;
 import com.powsybl.openrao.data.raoresultapi.ComputationStatus;
 import com.powsybl.openrao.data.raoresultapi.RaoResult;
@@ -109,7 +108,7 @@ public class SweCne {
         Reason reason = new Reason();
         RaoResult raoResult = sweCneHelper.getRaoResult();
         boolean isDivergent = sweCneHelper.isAnyContingencyInFailure() || raoResult.getComputationStatus() == ComputationStatus.FAILURE;
-        boolean isUnsecure = raoResult.getFunctionalCost(cracCreationContext.getCrac().getInstant(InstantKind.CURATIVE)) > 0 || isAngleMonitoringUnsecure(sweCneHelper.getCrac(), sweCneHelper.getRaoResult());
+        boolean isUnsecure = !raoResult.isSecure();
         if (isDivergent) {
             reason.setCode(DIVERGENCE_CODE);
             reason.setText(DIVERGENCE_TEXT);

--- a/data/result-exporter/swe-cne-exporter/src/main/java/com/powsybl/openrao/data/swecneexporter/SweCneUtil.java
+++ b/data/result-exporter/swe-cne-exporter/src/main/java/com/powsybl/openrao/data/swecneexporter/SweCneUtil.java
@@ -7,10 +7,6 @@
 
 package com.powsybl.openrao.data.swecneexporter;
 
-import com.powsybl.openrao.commons.Unit;
-import com.powsybl.openrao.data.cracapi.Crac;
-import com.powsybl.openrao.data.cracapi.InstantKind;
-import com.powsybl.openrao.data.raoresultapi.RaoResult;
 import com.powsybl.openrao.data.swecneexporter.xsd.AreaIDString;
 import com.powsybl.openrao.data.swecneexporter.xsd.ESMPDateTimeInterval;
 import com.powsybl.openrao.data.swecneexporter.xsd.PartyIDString;
@@ -32,11 +28,6 @@ import static com.powsybl.openrao.data.cneexportercommons.CneUtil.cutString;
  */
 public final class SweCneUtil {
     private SweCneUtil() {
-    }
-
-    public static boolean isAngleMonitoringUnsecure(Crac crac, RaoResult raoResult) {
-        // TODO : replace this with raoResult.isSecure(ANGLE) when ready
-        return crac.getAngleCnecs().stream().anyMatch(angleCnec -> raoResult.getMargin(crac.getInstant(InstantKind.CURATIVE), angleCnec, Unit.DEGREE) < 0);
     }
 
     // Creation of time interval

--- a/monitoring/angle-monitoring/src/main/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoring.java
+++ b/monitoring/angle-monitoring/src/main/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoring.java
@@ -7,6 +7,7 @@
 package com.powsybl.openrao.monitoring.anglemonitoring;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.RemedialAction;
@@ -79,5 +80,18 @@ public class RaoResultWithAngleMonitoring extends RaoResultClone {
     @Override
     public boolean isActivatedDuringState(State state, NetworkAction networkAction) {
         return isActivatedDuringState(state, (RemedialAction<?>) networkAction);
+    }
+
+    @Override
+    public boolean isSecure(Instant instant, PhysicalParameter... u) {
+        if (Set.of(u).contains(PhysicalParameter.ANGLE) && !angleMonitoringResult.isSecure()) {
+            return false;
+        }
+        return raoResult.isSecure(instant, u);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return raoResult.isSecure() && angleMonitoringResult.isSecure();
     }
 }

--- a/monitoring/angle-monitoring/src/main/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoring.java
+++ b/monitoring/angle-monitoring/src/main/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoring.java
@@ -84,10 +84,20 @@ public class RaoResultWithAngleMonitoring extends RaoResultClone {
 
     @Override
     public boolean isSecure(Instant instant, PhysicalParameter... u) {
-        if (Set.of(u).contains(PhysicalParameter.ANGLE) && !angleMonitoringResult.isSecure()) {
-            return false;
+        if (Set.of(u).contains(PhysicalParameter.ANGLE)) {
+            return raoResult.isSecure(instant, u) && angleMonitoringResult.isSecure();
+        } else {
+            return raoResult.isSecure(instant, u);
         }
-        return raoResult.isSecure(instant, u);
+    }
+
+    @Override
+    public boolean isSecure(PhysicalParameter... u) {
+        if (Set.of(u).contains(PhysicalParameter.ANGLE)) {
+            return raoResult.isSecure(u) && angleMonitoringResult.isSecure();
+        } else {
+            return raoResult.isSecure(u);
+        }
     }
 
     @Override

--- a/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoring.java
@@ -7,6 +7,7 @@
 package com.powsybl.openrao.monitoring.voltagemonitoring;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.RemedialAction;
@@ -87,5 +88,18 @@ public class RaoResultWithVoltageMonitoring extends RaoResultClone {
     @Override
     public boolean isActivatedDuringState(State state, NetworkAction networkAction) {
         return isActivatedDuringState(state, (RemedialAction<?>) networkAction);
+    }
+
+    @Override
+    public boolean isSecure(Instant instant, PhysicalParameter... u) {
+        if (Set.of(u).contains(PhysicalParameter.VOLTAGE) && !voltageMonitoringResult.isSecure()) {
+            return false;
+        }
+        return raoResult.isSecure(instant, u);
+    }
+
+    @Override
+    public boolean isSecure() {
+        return raoResult.isSecure() && voltageMonitoringResult.isSecure();
     }
 }

--- a/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoring.java
@@ -92,10 +92,20 @@ public class RaoResultWithVoltageMonitoring extends RaoResultClone {
 
     @Override
     public boolean isSecure(Instant instant, PhysicalParameter... u) {
-        if (Set.of(u).contains(PhysicalParameter.VOLTAGE) && !voltageMonitoringResult.isSecure()) {
-            return false;
+        if (Set.of(u).contains(PhysicalParameter.VOLTAGE)) {
+            return raoResult.isSecure(instant, u) && voltageMonitoringResult.isSecure();
+        } else {
+            return raoResult.isSecure(instant, u);
         }
-        return raoResult.isSecure(instant, u);
+    }
+
+    @Override
+    public boolean isSecure(PhysicalParameter... u) {
+        if (Set.of(u).contains(PhysicalParameter.VOLTAGE)) {
+            return raoResult.isSecure(u) && voltageMonitoringResult.isSecure();
+        } else {
+            return raoResult.isSecure(u);
+        }
     }
 
     @Override

--- a/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoringResult.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoringResult.java
@@ -149,4 +149,8 @@ public class VoltageMonitoringResult {
         }
         return constraints;
     }
+
+    public boolean isSecure() {
+        return getStatus() == Status.SECURE;
+    }
 }

--- a/monitoring/voltage-monitoring/src/test/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoringTest.java
+++ b/monitoring/voltage-monitoring/src/test/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoringTest.java
@@ -557,6 +557,7 @@ class VoltageMonitoringTest {
         assertEquals(SECURE, voltageMonitoringResult.getStatus());
         assertEquals(1, voltageMonitoringResult.getAppliedRas().size());
         assertEquals(Set.of(networkAction), voltageMonitoringResult.getAppliedRas().get(crac.getState("co", curativeInstant)));
-        assertTrue(voltageMonitoringResult.isSecure());    }
+        assertTrue(voltageMonitoringResult.isSecure());
+    }
 }
 

--- a/monitoring/voltage-monitoring/src/test/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoringTest.java
+++ b/monitoring/voltage-monitoring/src/test/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoringTest.java
@@ -130,6 +130,7 @@ class VoltageMonitoringTest {
         assertEquals(SECURE, voltageMonitoringResult.getStatus());
         assertTrue(voltageMonitoringResult.getConstrainedElements().isEmpty());
         assertEquals(List.of("All voltage CNECs are secure."), voltageMonitoringResult.printConstraints());
+        assertTrue(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -142,6 +143,7 @@ class VoltageMonitoringTest {
         assertEquals(SECURE, voltageMonitoringResult.getStatus());
         assertTrue(voltageMonitoringResult.getConstrainedElements().isEmpty());
         assertEquals(List.of("All voltage CNECs are secure."), voltageMonitoringResult.printConstraints());
+        assertTrue(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -154,6 +156,7 @@ class VoltageMonitoringTest {
         assertEquals(Set.of(crac.getVoltageCnec("vc")), voltageMonitoringResult.getConstrainedElements());
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL1 at state preventive has a voltage of 400 - 400 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -166,6 +169,7 @@ class VoltageMonitoringTest {
         assertEquals(Set.of(crac.getVoltageCnec("vc")), voltageMonitoringResult.getConstrainedElements());
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL1 at state preventive has a voltage of 400 - 400 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -186,6 +190,7 @@ class VoltageMonitoringTest {
         assertEquals(383., voltageMonitoringResult.getMaxVoltage(vc2), VOLTAGE_TOLERANCE);
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL2 at state preventive has a voltage of 368 - 368 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -206,6 +211,7 @@ class VoltageMonitoringTest {
         assertEquals(383., voltageMonitoringResult.getMaxVoltage(vc2), VOLTAGE_TOLERANCE);
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL2 at state preventive has a voltage of 368 - 368 kV.", "Network element VL3 at state preventive has a voltage of 383 - 383 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -226,6 +232,7 @@ class VoltageMonitoringTest {
         assertEquals(400., voltageMonitoringResult.getMaxVoltage(vc2), VOLTAGE_TOLERANCE);
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL3 at state preventive has a voltage of 400 - 400 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -246,6 +253,7 @@ class VoltageMonitoringTest {
         assertEquals(400., voltageMonitoringResult.getMaxVoltage(vc2), VOLTAGE_TOLERANCE);
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL2 at state preventive has a voltage of 368 - 368 kV.", "Network element VL3 at state preventive has a voltage of 400 - 400 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -267,6 +275,7 @@ class VoltageMonitoringTest {
         assertEquals(387., voltageMonitoringResult.getMaxVoltage(vc2), VOLTAGE_TOLERANCE);
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL2 at state preventive has a voltage of 379 - 379 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -294,6 +303,7 @@ class VoltageMonitoringTest {
                 "Network element VL3 at state coL2 - curative has a voltage of 400 - 400 kV.",
                 "Network element VL3 at state coL1L2 - curative has a voltage of 400 - 400 kV."),
             voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -320,6 +330,7 @@ class VoltageMonitoringTest {
         assertEquals(393., voltageMonitoringResult.getMinVoltage(vc2b), VOLTAGE_TOLERANCE);
         assertEquals(393., voltageMonitoringResult.getMaxVoltage(vc2b), VOLTAGE_TOLERANCE);
         assertEquals(List.of("All voltage CNECs are secure."), voltageMonitoringResult.printConstraints());
+        assertTrue(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -339,6 +350,7 @@ class VoltageMonitoringTest {
         assertEquals(368., voltageMonitoringResult.getMaxVoltage(vc), VOLTAGE_TOLERANCE);
         assertEquals(List.of("Some voltage CNECs are not secure:",
             "Network element VL2 at state co3 - curative has a voltage of 368 - 368 kV."), voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -363,6 +375,7 @@ class VoltageMonitoringTest {
                 "Network element VL45 at state preventive has a voltage of 144 - 148 kV.",
                 "Network element VL46 at state preventive has a voltage of 143 - 148 kV."),
             voltageMonitoringResult.printConstraints());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     public void setUpCracFactory(String networkFileName) {
@@ -395,6 +408,7 @@ class VoltageMonitoringTest {
         assertEquals(0, voltageMonitoringResult.getAppliedRas().size());
         assertEquals(Double.NaN, voltageMonitoringResult.getMinVoltage(vcPrev));
         assertEquals(Double.NaN, voltageMonitoringResult.getMaxVoltage(vcPrev));
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -415,6 +429,7 @@ class VoltageMonitoringTest {
 
         assertEquals(HIGH_VOLTAGE_CONSTRAINT, voltageMonitoringResult.getStatus());
         assertEquals(0, voltageMonitoringResult.getAppliedRas().size());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -434,6 +449,7 @@ class VoltageMonitoringTest {
 
         assertEquals(SECURE, voltageMonitoringResult.getStatus());
         assertEquals(0, voltageMonitoringResult.getAppliedRas().size());
+        assertTrue(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -445,6 +461,7 @@ class VoltageMonitoringTest {
 
         assertEquals(0, voltageMonitoringResult.getAppliedRas().size());
         assertEquals(HIGH_VOLTAGE_CONSTRAINT, voltageMonitoringResult.getStatus());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -471,6 +488,7 @@ class VoltageMonitoringTest {
         assertEquals(1, voltageMonitoringResult.getAppliedRas().size());
         assertEquals(Set.of(networkAction), voltageMonitoringResult.getAppliedRas().get(crac.getState("co", curativeInstant)));
         assertEquals(HIGH_VOLTAGE_CONSTRAINT, voltageMonitoringResult.getStatus());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -497,6 +515,7 @@ class VoltageMonitoringTest {
         assertEquals(1, voltageMonitoringResult.getAppliedRas().size());
         assertEquals(Set.of(networkAction), voltageMonitoringResult.getAppliedRas().get(crac.getState("co", curativeInstant)));
         assertEquals(LOW_VOLTAGE_CONSTRAINT, voltageMonitoringResult.getStatus());
+        assertFalse(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -517,6 +536,7 @@ class VoltageMonitoringTest {
         assertEquals(SECURE, voltageMonitoringResult.getStatus());
         assertEquals(1, voltageMonitoringResult.getAppliedRas().size());
         assertEquals(Set.of(networkAction), voltageMonitoringResult.getAppliedRas().get(crac.getState("co", curativeInstant)));
+        assertTrue(voltageMonitoringResult.isSecure());
     }
 
     @Test
@@ -537,6 +557,6 @@ class VoltageMonitoringTest {
         assertEquals(SECURE, voltageMonitoringResult.getStatus());
         assertEquals(1, voltageMonitoringResult.getAppliedRas().size());
         assertEquals(Set.of(networkAction), voltageMonitoringResult.getAppliedRas().get(crac.getState("co", curativeInstant)));
-    }
+        assertTrue(voltageMonitoringResult.isSecure());    }
 }
 

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImpl.java
@@ -165,7 +165,7 @@ public class FailedRaoResultImpl implements RaoResult {
     }
 
     @Override
-    public boolean isSecure() {
+    public boolean isSecure(PhysicalParameter... u) {
         throw new OpenRaoException(SHOULD_NOT_BE_USED);
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImpl.java
@@ -163,4 +163,9 @@ public class FailedRaoResultImpl implements RaoResult {
     public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
         throw new OpenRaoException(SHOULD_NOT_BE_USED);
     }
+
+    @Override
+    public boolean isSecure() {
+        throw new OpenRaoException(SHOULD_NOT_BE_USED);
+    }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImpl.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.searchtreerao.result.impl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.*;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
@@ -155,6 +156,11 @@ public class FailedRaoResultImpl implements RaoResult {
 
     @Override
     public OptimizationStepsExecuted getOptimizationStepsExecuted() {
+        throw new OpenRaoException(SHOULD_NOT_BE_USED);
+    }
+
+    @Override
+    public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
         throw new OpenRaoException(SHOULD_NOT_BE_USED);
     }
 }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
@@ -299,8 +299,19 @@ public class OneStateOnlyRaoResultImpl implements RaoResult {
 
     @Override
     public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
-        // TODO
-        return false;
+        if (ComputationStatus.FAILURE.equals(getComputationStatus())) {
+            return false;
+        }
+        if (Arrays.stream(u).toList().contains(PhysicalParameter.FLOW)) {
+            return optimizedFlowCnecs.stream()
+                    .noneMatch(flowCnec -> getMargin(optimizedInstant, flowCnec, Unit.MEGAWATT) < 0);
+        }
+        return true;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return isSecure(optimizedState.getInstant(), PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE);
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
@@ -310,8 +310,8 @@ public class OneStateOnlyRaoResultImpl implements RaoResult {
     }
 
     @Override
-    public boolean isSecure() {
-        return isSecure(optimizedState.getInstant(), PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE);
+    public boolean isSecure(PhysicalParameter... u) {
+        return isSecure(optimizedState.getInstant(), u);
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
@@ -302,11 +302,7 @@ public class OneStateOnlyRaoResultImpl implements RaoResult {
         if (ComputationStatus.FAILURE.equals(getComputationStatus())) {
             return false;
         }
-        if (Arrays.stream(u).toList().contains(PhysicalParameter.FLOW)) {
-            return optimizedFlowCnecs.stream()
-                    .noneMatch(flowCnec -> getMargin(optimizedInstant, flowCnec, Unit.MEGAWATT) < 0);
-        }
-        return true;
+        return getFunctionalCost(optimizedInstant) < 0;
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImpl.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.searchtreerao.result.impl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.*;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
@@ -294,6 +295,12 @@ public class OneStateOnlyRaoResultImpl implements RaoResult {
         } else {
             throw new OpenRaoException("The RaoResult object should not be modified outside of its usual routine");
         }
+    }
+
+    @Override
+    public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
+        // TODO
+        return false;
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
@@ -591,7 +591,7 @@ public class PreventiveAndCurativesRaoResultImpl implements RaoResult {
         if (ComputationStatus.FAILURE.equals(getComputationStatus())) {
             return false;
         }
-        return getCost(optimizedInstant) < 0;
+        return getFunctionalCost(optimizedInstant) < 0;
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
@@ -588,8 +588,15 @@ public class PreventiveAndCurativesRaoResultImpl implements RaoResult {
 
     @Override
     public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
-        // TODO
-        return false;
+        if (ComputationStatus.FAILURE.equals(getComputationStatus())) {
+            return false;
+        }
+        return getCost(optimizedInstant) < 0;
+    }
+
+    @Override
+    public boolean isSecure() {
+        return isSecure(crac.getLastInstant(), PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE);
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.searchtreerao.result.impl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.*;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
@@ -583,6 +584,12 @@ public class PreventiveAndCurativesRaoResultImpl implements RaoResult {
         } else {
             throw new OpenRaoException("The RaoResult object should not be modified outside of its usual routine");
         }
+    }
+
+    @Override
+    public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
+        // TODO
+        return false;
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/PreventiveAndCurativesRaoResultImpl.java
@@ -595,8 +595,8 @@ public class PreventiveAndCurativesRaoResultImpl implements RaoResult {
     }
 
     @Override
-    public boolean isSecure() {
-        return isSecure(crac.getLastInstant(), PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE);
+    public boolean isSecure(PhysicalParameter... u) {
+        return isSecure(crac.getLastInstant(), u);
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImpl.java
@@ -197,6 +197,11 @@ public class UnoptimizedRaoResultImpl implements RaoResult {
     }
 
     @Override
+    public boolean isSecure() {
+        throw new OpenRaoException("Unavailable method for unoptimized RaoResult.");
+    }
+
+    @Override
     public OptimizationStepsExecuted getOptimizationStepsExecuted() {
         return optimizationStepsExecuted;
     }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImpl.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.searchtreerao.result.impl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.RemedialAction;
@@ -188,6 +189,11 @@ public class UnoptimizedRaoResultImpl implements RaoResult {
         } else {
             throw new OpenRaoException("The RaoResult object should not be modified outside of its usual routine");
         }
+    }
+
+    @Override
+    public boolean isSecure(Instant optimizedInstant, PhysicalParameter... u) {
+        throw new OpenRaoException("Unavailable method for unoptimized RaoResult.");
     }
 
     @Override

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImpl.java
@@ -197,7 +197,7 @@ public class UnoptimizedRaoResultImpl implements RaoResult {
     }
 
     @Override
-    public boolean isSecure() {
+    public boolean isSecure(PhysicalParameter... u) {
         throw new OpenRaoException("Unavailable method for unoptimized RaoResult.");
     }
 

--- a/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImplTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/result/impl/FailedRaoResultImplTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.searchtreerao.result.impl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.cnec.AngleCnec;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
@@ -61,6 +62,8 @@ class FailedRaoResultImplTest {
         assertThrows(OpenRaoException.class, () -> failedRaoResultImpl.getOptimizedSetPointsOnState(state));
         assertThrows(OpenRaoException.class, failedRaoResultImpl::getOptimizationStepsExecuted);
         assertThrows(OpenRaoException.class, () -> failedRaoResultImpl.setOptimizationStepsExecuted(OptimizationStepsExecuted.FIRST_PREVENTIVE_ONLY));
+        assertThrows(OpenRaoException.class, failedRaoResultImpl::isSecure);
+        assertThrows(OpenRaoException.class, () -> failedRaoResultImpl.isSecure(optInstant, PhysicalParameter.FLOW));
     }
 
     @Test

--- a/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImplTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/result/impl/OneStateOnlyRaoResultImplTest.java
@@ -8,7 +8,6 @@
 package com.powsybl.openrao.searchtreerao.result.impl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
-import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.cracapi.*;
 import com.powsybl.openrao.data.cracapi.cnec.AngleCnec;
@@ -465,25 +464,22 @@ class OneStateOnlyRaoResultImplTest {
 
     @Test
     void testIsSecureOnSecureCase() {
-        when(optimizedState.isPreventive()).thenReturn(true);
+        when(optimizedState.getInstant()).thenReturn(curativeInstant);
+        when(output.getFunctionalCost(curativeInstant)).thenReturn(-10.);
+        assertTrue(output.isSecure());
+    }
 
-        assertTrue(output.isSecure(preventiveInstant, PhysicalParameter.FLOW));
+    @Test
+    void testIsSecureOnFailureCase() {
+        when(optimizedState.getInstant()).thenReturn(curativeInstant);
+        when(output.getComputationStatus()).thenReturn(ComputationStatus.FAILURE);
+        assertFalse(output.isSecure());
     }
 
     @Test
     void testIsSecureOnUnsecureCase() {
         when(optimizedState.getInstant()).thenReturn(curativeInstant);
-        when(optimizedState.isPreventive()).thenReturn(false);
-
-        // margins
-        when(cnec1state.isPreventive()).thenReturn(false);
-        when(cnec2state.isPreventive()).thenReturn(false);
-        Contingency contingency = mock(Contingency.class);
-        when(optimizedState.getContingency()).thenReturn(Optional.of(contingency));
-        when(cnec1state.getContingency()).thenReturn(Optional.of(mock(Contingency.class)));
-        when(cnec2state.getContingency()).thenReturn(Optional.of(contingency));
-        when(cnec2state.compareTo(optimizedState)).thenReturn(-1);
-
-        assertFalse(output.isSecure(curativeInstant, PhysicalParameter.FLOW));
+        when(output.getFunctionalCost(curativeInstant)).thenReturn(10.);
+        assertFalse(output.isSecure());
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImplTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/result/impl/UnoptimizedRaoResultImplTest.java
@@ -8,6 +8,7 @@
 package com.powsybl.openrao.searchtreerao.result.impl;
 
 import com.powsybl.openrao.commons.OpenRaoException;
+import com.powsybl.openrao.commons.PhysicalParameter;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.State;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
@@ -281,5 +282,11 @@ class UnoptimizedRaoResultImplTest {
         assertEquals("The RaoResult object should not be modified outside of its usual routine", exception.getMessage());
         exception = assertThrows(OpenRaoException.class, () -> output.setOptimizationStepsExecuted(OptimizationStepsExecuted.FIRST_PREVENTIVE_FELLBACK_TO_INITIAL_SITUATION));
         assertEquals("The RaoResult object should not be modified outside of its usual routine", exception.getMessage());
+    }
+
+    @Test
+    void testIsSecureNotAvailableForUnoptimizedRaoResultImpls() {
+        assertThrows(OpenRaoException.class, () -> output.isSecure(autoInstant, PhysicalParameter.FLOW, PhysicalParameter.ANGLE, PhysicalParameter.VOLTAGE));
+        assertThrows(OpenRaoException.class, () -> output.isSecure());
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
No


**What kind of change does this PR introduce?**
New feature


**What is the new behavior (if this is a feature change)?**
RaoResult objects now provides 3 new methods that allow client to assess the RAO result security status (i.e. positive margin on all Cnecs) , for multiple instants of optimization, and separately for each of the Cnec kind (Flow, Voltage and Angle).
These methods are :

- boolean isSecure() -> Assess security on last optimisation instant, taking into account all Cnec kinds
- boolean isSecure(PhysicalParameter...) -> Assess security on last optimisation instant, taking into account a potential subset of Cnec kinds
- boolean isSecure(Instant, PhysicalParameter...) -> Assess security on a given optimisation instant, taking into account a potential subset of Cnec kinds

This PR also add a method getLastInstant() to the CRAC API that allow to get the last instant based on order (biggest order one). This instant should correspond to the final optimisation instant.

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
