### PR TITLE
New CNEC naming convention

### DIFF
--- a/data/crac-creation/crac-creator-csa-profiles/src/main/java/com/powsybl/openrao/data/craccreation/creator/csaprofile/craccreator/cnec/AbstractCnecCreator.java
+++ b/data/crac-creation/crac-creator-csa-profiles/src/main/java/com/powsybl/openrao/data/craccreation/creator/csaprofile/craccreator/cnec/AbstractCnecCreator.java
@@ -70,15 +70,28 @@ public abstract class AbstractCnecCreator {
 
     protected String getCnecName(String instantId, Contingency contingency) {
         // Need to include the mRID in the name in case the AssessedElement's name is not unique
-        return assessedElementName + " (" + assessedElementId + ") - " + (contingency == null ? "" : contingency.getName() + " - ") + instantId;
+        return "%s (%s) - %s%s".formatted(assessedElementName, assessedElementId, contingency == null ? "" : contingency.getName() + " - ", instantId);
+    }
+
+    protected String getCnecName(String instantId, Contingency contingency, int tatlDuration) {
+        // Add TATL duration in case to CNECs of the same instant are created with different TATLs
+        return "%s - TATL %s".formatted(getCnecName(instantId, contingency), tatlDuration);
     }
 
     protected void addCnecBaseInformation(CnecAdder<?> cnecAdder, Contingency contingency, String instantId) {
         String cnecName = getCnecName(instantId, contingency);
         cnecAdder.withContingency(contingency == null ? null : contingency.getId())
-                    .withId(cnecName)
-                    .withName(cnecName)
-                    .withInstant(instantId);
+            .withId(cnecName)
+            .withName(cnecName)
+            .withInstant(instantId);
+    }
+
+    protected void addCnecBaseInformation(CnecAdder<?> cnecAdder, Contingency contingency, String instantId, int tatlDuration) {
+        String cnecName = getCnecName(instantId, contingency, tatlDuration);
+        cnecAdder.withContingency(contingency == null ? null : contingency.getId())
+            .withId(cnecName)
+            .withName(cnecName)
+            .withInstant(instantId);
     }
 
     protected void markCnecAsImportedAndHandleRejectedContingencies(String instantId, Contingency contingency) {

--- a/data/crac-creation/crac-creator-csa-profiles/src/test/java/com/powsybl/openrao/data/craccreation/creator/csaprofile/craccreator/CsaProfileCracCreatorTest.java
+++ b/data/crac-creation/crac-creator-csa-profiles/src/test/java/com/powsybl/openrao/data/craccreation/creator/csaprofile/craccreator/CsaProfileCracCreatorTest.java
@@ -48,7 +48,7 @@ class CsaProfileCracCreatorTest {
         assertEquals(6, importedCrac.getFlowCnecs().size());
         CsaProfileCracCreationTestUtil.assertFlowCnecEquality(importedCrac.getFlowCnec("RTE_FFR2AA1--FFR3AA1--2 (079f1887-f33e-49ef-b1ff-22e871055fd0) - RTE_co1_fr2_fr3_1 - curative"), "RTE_FFR2AA1--FFR3AA1--2 (079f1887-f33e-49ef-b1ff-22e871055fd0) - RTE_co1_fr2_fr3_1 - curative", "RTE_FFR2AA1--FFR3AA1--2 (079f1887-f33e-49ef-b1ff-22e871055fd0) - RTE_co1_fr2_fr3_1 - curative",
             "FFR2AA1--FFR3AA1--2", curativeInstant, "co1_fr2_fr3_1", 2500., -2500., Side.RIGHT);
-        CsaProfileCracCreationTestUtil.assertFlowCnecEquality(importedCrac.getFlowCnec("RTE_FFR3AA1--FFR5AA1--1 (755832d8-220a-4e5a-b133-dfd27b3c8a78) - RTE_co1_fr2_fr3_1 - outage"), "RTE_FFR3AA1--FFR5AA1--1 (755832d8-220a-4e5a-b133-dfd27b3c8a78) - RTE_co1_fr2_fr3_1 - outage", "RTE_FFR3AA1--FFR5AA1--1 (755832d8-220a-4e5a-b133-dfd27b3c8a78) - RTE_co1_fr2_fr3_1 - outage",
+        CsaProfileCracCreationTestUtil.assertFlowCnecEquality(importedCrac.getFlowCnec("RTE_FFR3AA1--FFR5AA1--1 (755832d8-220a-4e5a-b133-dfd27b3c8a78) - RTE_co1_fr2_fr3_1 - outage - TATL 60"), "RTE_FFR3AA1--FFR5AA1--1 (755832d8-220a-4e5a-b133-dfd27b3c8a78) - RTE_co1_fr2_fr3_1 - outage - TATL 60", "RTE_FFR3AA1--FFR5AA1--1 (755832d8-220a-4e5a-b133-dfd27b3c8a78) - RTE_co1_fr2_fr3_1 - outage - TATL 60",
             "FFR3AA1--FFR5AA1--1", outageInstant, "co1_fr2_fr3_1", 1500., -1500., Side.RIGHT);
         CsaProfileCracCreationTestUtil.assertFlowCnecEquality(importedCrac.getFlowCnec("RTE_FFR2AA1--DDE3AA1--1 (77320d6c-7880-43b1-ac28-e27a85ebda82) - preventive"), "RTE_FFR2AA1--DDE3AA1--1 (77320d6c-7880-43b1-ac28-e27a85ebda82) - preventive", "RTE_FFR2AA1--DDE3AA1--1 (77320d6c-7880-43b1-ac28-e27a85ebda82) - preventive",
             "FFR2AA1--DDE3AA1--1", preventiveInstant, null, 1000., -1000., Side.RIGHT);
@@ -56,7 +56,7 @@ class CsaProfileCracCreatorTest {
             "FFR3AA1--FFR5AA1--1", curativeInstant, "co1_fr2_fr3_1", 1000., -1000., Side.RIGHT);
         CsaProfileCracCreationTestUtil.assertFlowCnecEquality(importedCrac.getFlowCnec("TENNET_TSO_NNL2AA1--BBE3AA1--1 (f0208d08-2ed5-4d92-91a1-4e89ac71e17e) - preventive"), "TENNET_TSO_NNL2AA1--BBE3AA1--1 (f0208d08-2ed5-4d92-91a1-4e89ac71e17e) - preventive", "TENNET_TSO_NNL2AA1--BBE3AA1--1 (f0208d08-2ed5-4d92-91a1-4e89ac71e17e) - preventive",
             "NNL2AA1--BBE3AA1--1", preventiveInstant, null, 5000., -5000., Side.RIGHT);
-        CsaProfileCracCreationTestUtil.assertFlowCnecEquality(importedCrac.getFlowCnec("RTE_FFR2AA1--DDE3AA1--1 (f7708112-b880-4674-98a1-b005a01a61d5) - RTE_co1_fr2_fr3_1 - outage"), "RTE_FFR2AA1--DDE3AA1--1 (f7708112-b880-4674-98a1-b005a01a61d5) - RTE_co1_fr2_fr3_1 - outage", "RTE_FFR2AA1--DDE3AA1--1 (f7708112-b880-4674-98a1-b005a01a61d5) - RTE_co1_fr2_fr3_1 - outage",
+        CsaProfileCracCreationTestUtil.assertFlowCnecEquality(importedCrac.getFlowCnec("RTE_FFR2AA1--DDE3AA1--1 (f7708112-b880-4674-98a1-b005a01a61d5) - RTE_co1_fr2_fr3_1 - outage - TATL 60"), "RTE_FFR2AA1--DDE3AA1--1 (f7708112-b880-4674-98a1-b005a01a61d5) - RTE_co1_fr2_fr3_1 - outage - TATL 60", "RTE_FFR2AA1--DDE3AA1--1 (f7708112-b880-4674-98a1-b005a01a61d5) - RTE_co1_fr2_fr3_1 - outage - TATL 60",
             "FFR2AA1--DDE3AA1--1", outageInstant, "co1_fr2_fr3_1", 1200., -1200., Side.RIGHT);
 
         // Check PST RAs

--- a/data/crac-creation/crac-creator-csa-profiles/src/test/java/com/powsybl/openrao/data/craccreation/creator/csaprofile/craccreator/cnec/FlowCnecCreationTest.java
+++ b/data/crac-creation/crac-creator-csa-profiles/src/test/java/com/powsybl/openrao/data/craccreation/creator/csaprofile/craccreator/cnec/FlowCnecCreationTest.java
@@ -316,8 +316,8 @@ class FlowCnecCreationTest {
                 preventiveInstant, null,
                 +1000d, -1000d, Side.LEFT);
         CsaProfileCracCreationTestUtil.assertFlowCnecEquality(listFlowCnecs.get(5),
-                "REE_AE3 (989535e7-3789-47e7-8ba7-da7be9962a15) - REE_CO3 - auto",
-                "REE_AE3 (989535e7-3789-47e7-8ba7-da7be9962a15) - REE_CO3 - auto",
+                "REE_AE3 (989535e7-3789-47e7-8ba7-da7be9962a15) - REE_CO3 - auto - TATL 600",
+                "REE_AE3 (989535e7-3789-47e7-8ba7-da7be9962a15) - REE_CO3 - auto - TATL 600",
                 "048badc5-c766-11e1-8775-005056c00008",
                 autoInstant, "13334fdf-9cc2-4341-adb6-1281269040b4",
                 +500.0, -500.0, Side.LEFT);
@@ -479,8 +479,8 @@ class FlowCnecCreationTest {
 
         CsaProfileCracCreationTestUtil.assertFlowCnecEquality(
                 importedFlowCnecs.get(0),
-                "RTE_AE1 (183829bd-5c60-4c04-ad57-c72a15a75047) - RTE_CO1 - auto",
-                "RTE_AE1 (183829bd-5c60-4c04-ad57-c72a15a75047) - RTE_CO1 - auto",
+                "RTE_AE1 (183829bd-5c60-4c04-ad57-c72a15a75047) - RTE_CO1 - auto - TATL 600",
+                "RTE_AE1 (183829bd-5c60-4c04-ad57-c72a15a75047) - RTE_CO1 - auto - TATL 600",
                 "b58bf21a-096a-4dae-9a01-3f03b60c24c7",
                 autoInstant,
                 "bbda9fe0-77e0-4f8e-b9d9-4402a539f2b7",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**

The FlowCNECs naming convention has slightly evolved to included the TATL duration for curative CNECS in order to avoid conflicts of two CNECs having the same id if two TATLs correpond to the same instant (new pattern: `TSO_AE (mRID) - TSO_CO - instant - TATL duration`)

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
