### PR TITLE
Parallelize network cloning

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/searchtree/algorithms/SearchTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/searchtree/algorithms/SearchTree.java
@@ -210,16 +210,16 @@ public class SearchTree {
 
         TreeMap<NetworkActionCombination, Boolean> naCombinationsSorted = new TreeMap<>(this::deterministicNetworkActionCombinationComparison);
         naCombinationsSorted.putAll(bloomer.bloom(optimalLeaf, input.getOptimizationPerimeter().getNetworkActions()));
-        int amountOfCombinations = naCombinationsSorted.size();
+        int numberOfCombinations = naCombinationsSorted.size();
 
-        networkPool.initClones(amountOfCombinations);
+        networkPool.initClones(numberOfCombinations);
         if (naCombinationsSorted.isEmpty()) {
             TECHNICAL_LOGS.info("No more network action available");
             return;
         } else {
-            TECHNICAL_LOGS.info("Leaves to evaluate: {}", amountOfCombinations);
+            TECHNICAL_LOGS.info("Leaves to evaluate: {}", numberOfCombinations);
         }
-        AtomicInteger remainingLeaves = new AtomicInteger(amountOfCombinations);
+        AtomicInteger remainingLeaves = new AtomicInteger(numberOfCombinations);
         List<ForkJoinTask<Object>> tasks = naCombinationsSorted.keySet().stream().map(naCombination ->
             networkPool.submit(() -> optimizeOneLeaf(networkPool, naCombination, naCombinationsSorted, remainingLeaves))
         ).toList();

--- a/util/src/main/java/com/powsybl/openrao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/powsybl/openrao/util/MultipleNetworkPool.java
@@ -66,7 +66,7 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
         AtomicInteger remainingClones = new AtomicInteger(requiredClones);
         List<ForkJoinTask<Network>> tasks = new ArrayList<>();
         try {
-            for (int i = 0; i < requiredClones; i++) {
+            for (int i = networkNumberOfClones; i < requiredClones; i++) {
                 int finalI = i;
                 tasks.add(this.submit(() -> createNetworkCopy(finalI, remainingClones)));
             }
@@ -74,7 +74,7 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
                 try {
                     boolean isSuccess = networksQueue.offer(task.get());
                     if (!isSuccess) {
-                        throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", networkNumberOfClones + 1));
+                        throw new OpenRaoException(String.format("Cannot offer copy n°'%d' in pool. Should not happen", networkNumberOfClones + 1));
                     } else {
                         networkNumberOfClones++;
                     }

--- a/util/src/main/java/com/powsybl/openrao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/powsybl/openrao/util/MultipleNetworkPool.java
@@ -9,9 +9,14 @@ package com.powsybl.openrao.util;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.iidm.serde.NetworkSerDe;
+import com.powsybl.openrao.commons.OpenRaoException;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.powsybl.openrao.commons.logs.OpenRaoLoggerProvider.TECHNICAL_LOGS;
 
@@ -32,9 +37,9 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
     @Override
     protected void cleanVariants(Network networkClone) {
         List<String> variantsToBeRemoved = networkClone.getVariantManager().getVariantIds().stream()
-                .filter(variantId -> !variantId.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
-                .filter(variantId -> !variantId.equals(stateSaveVariant))
-                .toList();
+            .filter(variantId -> !variantId.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
+            .filter(variantId -> !variantId.equals(stateSaveVariant))
+            .toList();
         variantsToBeRemoved.forEach(variantId -> networkClone.getVariantManager().removeVariant(variantId));
     }
 
@@ -58,18 +63,36 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
         String initialVariant = network.getVariantManager().getWorkingVariantId();
         network.getVariantManager().setWorkingVariant(targetVariant);
 
-        while (networkNumberOfClones < requiredClones) {
-            TECHNICAL_LOGS.debug("Copy n°{}", networkNumberOfClones + 1);
-            Network copy = NetworkSerDe.copy(network);
-            // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
-            // in cloned network, so we need to copy it again.
-            copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
-            boolean isSuccess = networksQueue.offer(copy);
-            if (!isSuccess) {
-                throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", networkNumberOfClones + 1));
+        AtomicInteger remainingClones = new AtomicInteger(requiredClones);
+        List<ForkJoinTask<Network>> tasks = new ArrayList<>();
+        try {
+            for (int i = 0; i < requiredClones; i++) {
+                int finalI = i;
+                tasks.add(this.submit(() -> createNetworkCopy(finalI, remainingClones)));
             }
-            networkNumberOfClones++;
+            for (ForkJoinTask<Network> task : tasks) {
+                try {
+                    boolean isSuccess = networksQueue.offer(task.get());
+                    if (!isSuccess) {
+                        throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", networkNumberOfClones + 1));
+                    }
+                } catch (ExecutionException e) {
+                    throw new OpenRaoException(e);
+                }
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
         network.getVariantManager().setWorkingVariant(initialVariant);
+    }
+
+    private Network createNetworkCopy(int finalI, AtomicInteger remainingClones) {
+        TECHNICAL_LOGS.debug("Copy n°{}", finalI + 1);
+        Network copy = NetworkSerDe.copy(network);
+        // The initial network working variant is VariantManagerConstants.INITIAL_VARIANT_ID
+        // in cloned network, so we need to copy it again.
+        copy.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, Arrays.asList(stateSaveVariant, workingVariant), true);
+        remainingClones.decrementAndGet();
+        return copy;
     }
 }

--- a/util/src/main/java/com/powsybl/openrao/util/MultipleNetworkPool.java
+++ b/util/src/main/java/com/powsybl/openrao/util/MultipleNetworkPool.java
@@ -75,6 +75,8 @@ public class MultipleNetworkPool extends AbstractNetworkPool {
                     boolean isSuccess = networksQueue.offer(task.get());
                     if (!isSuccess) {
                         throw new AssertionError(String.format("Cannot offer copy n°'%d' in pool. Should not happen", networkNumberOfClones + 1));
+                    } else {
+                        networkNumberOfClones++;
                     }
                 } catch (ExecutionException e) {
                     throw new OpenRaoException(e);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Performance improvement 


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When parallelizing contingency computations or network actions in search tree, the network pool starts by cloning the network for it to be used by multiple threads. These clones are created in the main thread, and cloning a big network can be slow. Thus we need to wait N x the time to clone one network (N being the number of computation threads).


**What is the new behavior (if this is a feature change)?**
The clones are now created on the N threads in parallel, thus dividing this wait time by N.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No
