### PR TITLE
Optimize curative perimeters only instead of all curative states

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
@@ -12,7 +12,6 @@ import com.powsybl.openrao.data.cracapi.*;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
 import com.powsybl.openrao.data.cracapi.networkaction.NetworkAction;
 import com.powsybl.openrao.data.cracapi.rangeaction.RangeAction;
-import com.powsybl.openrao.data.cracapi.usagerule.UsageMethod;
 import com.powsybl.openrao.data.raoresultapi.ComputationStatus;
 import com.powsybl.openrao.data.raoresultapi.OptimizationStepsExecuted;
 import com.powsybl.openrao.data.raoresultapi.RaoResult;
@@ -385,7 +384,6 @@ public class CastorFullOptimization {
         Set<RangeAction<?>> rangeActionsInSensi = new HashSet<>(crac.getRangeActions(curativePerimeter.getRaOptimisationState()));
         for (State curativeState : curativePerimeter.getAllStates()) {
             flowCnecsInSensi.addAll(crac.getFlowCnecs(curativeState));
-            rangeActionsInSensi.addAll(crac.getRangeActions(curativeState, UsageMethod.AVAILABLE));
         }
         return new PrePerimeterSensitivityAnalysis(flowCnecsInSensi, rangeActionsInSensi, raoParameters, toolProvider);
     }
@@ -402,7 +400,7 @@ public class CastorFullOptimization {
         State curativeState = curativePerimeter.getRaOptimisationState();
         TECHNICAL_LOGS.info("Optimizing curative state {}.", curativeState.getId());
 
-        OptimizationPerimeter optPerimeter = CurativeOptimizationPerimeter.buildForStates(curativeState, curativePerimeter.getAllStates(), crac, crac.getRangeActions(), network, raoParameters, prePerimeterSensitivityOutput);
+        OptimizationPerimeter optPerimeter = CurativeOptimizationPerimeter.buildForStates(curativeState, curativePerimeter.getAllStates(), crac, network, raoParameters, prePerimeterSensitivityOutput);
 
         SearchTreeParameters searchTreeParameters = SearchTreeParameters.create()
             .withConstantParametersOverAllRao(raoParameters, crac)

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
@@ -9,8 +9,10 @@ package com.powsybl.openrao.searchtreerao.castor.algorithm;
 import com.powsybl.openrao.commons.OpenRaoException;
 import com.powsybl.openrao.commons.RandomizedString;
 import com.powsybl.openrao.data.cracapi.*;
+import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
 import com.powsybl.openrao.data.cracapi.networkaction.NetworkAction;
 import com.powsybl.openrao.data.cracapi.rangeaction.RangeAction;
+import com.powsybl.openrao.data.cracapi.usagerule.UsageMethod;
 import com.powsybl.openrao.data.raoresultapi.ComputationStatus;
 import com.powsybl.openrao.data.raoresultapi.OptimizationStepsExecuted;
 import com.powsybl.openrao.data.raoresultapi.RaoResult;
@@ -354,18 +356,22 @@ public class CastorFullOptimization {
             curativeStates.forEach(curativeState -> contingencyScenarioResults.put(curativeState, new SkippedOptimizationResultImpl(curativeState, new HashSet<>(), new HashSet<>(), ComputationStatus.FAILURE, sensitivityFailureOvercost)));
         } else if (!automatonsOnly) {
             boolean allPreviousPerimetersSucceded = true;
+            PrePerimeterResult previousPerimeterResult = preCurativeResult;
             // Optimize curative instant
             for (Perimeter curativePerimeter : optimizedScenario.getCurativePerimeters()) {
-                for (State curativeState : curativePerimeter.getAllStates()) {
-                    if (allPreviousPerimetersSucceded) {
-                        OptimizationResult curativeResult = optimizeCurativeState(curativeState, crac, networkClone,
-                            raoParameters, stateTree, toolProvider, curativeTreeParameters, initialSensitivityOutput, preCurativeResult);
-                        allPreviousPerimetersSucceded = curativeResult.getSensitivityStatus() == DEFAULT;
-                        contingencyScenarioResults.put(curativeState, curativeResult);
-                        applyRemedialActions(networkClone, curativeResult, curativeState);
-                    } else {
-                        contingencyScenarioResults.put(curativeState, new SkippedOptimizationResultImpl(curativeState, new HashSet<>(), new HashSet<>(), ComputationStatus.FAILURE, sensitivityFailureOvercost));
-                    }
+                State curativeState = curativePerimeter.getRaOptimisationState();
+                if (previousPerimeterResult == null) {
+                    previousPerimeterResult = getPreCurativePerimeterSensitivityAnalysis(crac, curativePerimeter, toolProvider).runBasedOnInitialResults(networkClone, raoInput.getCrac(), previousPerimeterResult, previousPerimeterResult, stateTree.getOperatorsNotSharingCras(), null);
+                }
+                if (allPreviousPerimetersSucceded) {
+                    OptimizationResult curativeResult = optimizeCurativePerimeter(curativePerimeter, crac, networkClone,
+                        raoParameters, stateTree, toolProvider, curativeTreeParameters, initialSensitivityOutput, previousPerimeterResult);
+                    allPreviousPerimetersSucceded = curativeResult.getSensitivityStatus() == DEFAULT;
+                    contingencyScenarioResults.put(curativeState, curativeResult);
+                    applyRemedialActions(networkClone, curativeResult, curativeState);
+                    previousPerimeterResult = null;
+                } else {
+                    contingencyScenarioResults.put(curativeState, new SkippedOptimizationResultImpl(curativeState, new HashSet<>(), new HashSet<>(), ComputationStatus.FAILURE, sensitivityFailureOvercost));
                 }
             }
         }
@@ -374,18 +380,29 @@ public class CastorFullOptimization {
         return null;
     }
 
-    private OptimizationResult optimizeCurativeState(State curativeState,
-                                                     Crac crac,
-                                                     Network network,
-                                                     RaoParameters raoParameters,
-                                                     StateTree stateTree,
-                                                     ToolProvider toolProvider,
-                                                     TreeParameters curativeTreeParameters,
-                                                     PrePerimeterResult initialSensitivityOutput,
-                                                     PrePerimeterResult prePerimeterSensitivityOutput) {
+    private PrePerimeterSensitivityAnalysis getPreCurativePerimeterSensitivityAnalysis(Crac crac, Perimeter curativePerimeter, ToolProvider toolProvider) {
+        Set<FlowCnec> flowCnecsInSensi = crac.getFlowCnecs(curativePerimeter.getRaOptimisationState());
+        Set<RangeAction<?>> rangeActionsInSensi = new HashSet<>(crac.getRangeActions(curativePerimeter.getRaOptimisationState()));
+        for (State curativeState : curativePerimeter.getAllStates()) {
+            flowCnecsInSensi.addAll(crac.getFlowCnecs(curativeState));
+            rangeActionsInSensi.addAll(crac.getRangeActions(curativeState, UsageMethod.AVAILABLE));
+        }
+        return new PrePerimeterSensitivityAnalysis(flowCnecsInSensi, rangeActionsInSensi, raoParameters, toolProvider);
+    }
+
+    private OptimizationResult optimizeCurativePerimeter(Perimeter curativePerimeter,
+                                                         Crac crac,
+                                                         Network network,
+                                                         RaoParameters raoParameters,
+                                                         StateTree stateTree,
+                                                         ToolProvider toolProvider,
+                                                         TreeParameters curativeTreeParameters,
+                                                         PrePerimeterResult initialSensitivityOutput,
+                                                         PrePerimeterResult prePerimeterSensitivityOutput) {
+        State curativeState = curativePerimeter.getRaOptimisationState();
         TECHNICAL_LOGS.info("Optimizing curative state {}.", curativeState.getId());
 
-        OptimizationPerimeter optPerimeter = CurativeOptimizationPerimeter.build(curativeState, crac, network, raoParameters, prePerimeterSensitivityOutput);
+        OptimizationPerimeter optPerimeter = CurativeOptimizationPerimeter.buildForStates(curativeState, curativePerimeter.getAllStates(), crac, crac.getRangeActions(), network, raoParameters, prePerimeterSensitivityOutput);
 
         SearchTreeParameters searchTreeParameters = SearchTreeParameters.create()
             .withConstantParametersOverAllRao(raoParameters, crac)

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/CastorFullOptimization.java
@@ -381,7 +381,7 @@ public class CastorFullOptimization {
 
     private PrePerimeterSensitivityAnalysis getPreCurativePerimeterSensitivityAnalysis(Crac crac, Perimeter curativePerimeter, ToolProvider toolProvider) {
         Set<FlowCnec> flowCnecsInSensi = crac.getFlowCnecs(curativePerimeter.getRaOptimisationState());
-        Set<RangeAction<?>> rangeActionsInSensi = new HashSet<>(crac.getRangeActions(curativePerimeter.getRaOptimisationState()));
+        Set<RangeAction<?>> rangeActionsInSensi = new HashSet<>(crac.getPotentiallyAvailableRangeActions(curativePerimeter.getRaOptimisationState()));
         for (State curativeState : curativePerimeter.getAllStates()) {
             flowCnecsInSensi.addAll(crac.getFlowCnecs(curativeState));
         }

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/Perimeter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/Perimeter.java
@@ -47,10 +47,6 @@ public class Perimeter {
         return raOptimisationState;
     }
 
-    public Set<State> getCnecStates() {
-        return cnecStates;
-    }
-
     public Set<State> getAllStates() {
         Set<State> states = new HashSet<>(cnecStates);
         states.add(raOptimisationState);

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/RaoLogger.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/RaoLogger.java
@@ -189,10 +189,8 @@ public final class RaoLogger {
             ));
             contingencyScenario.getCurativePerimeters()
                 .forEach(
-                    curativePerimeter -> curativePerimeter.getAllStates().forEach(
-                        curativeState -> mostLimitingElementsAndMargins.putAll(
-                            getMostLimitingElementsAndMargins(contingencyOptimizationResults.get(curativeState), Set.of(curativeState), unit, relativePositiveMargins, numberOfLoggedElements)
-                        )
+                    curativePerimeter -> mostLimitingElementsAndMargins.putAll(
+                        getMostLimitingElementsAndMargins(contingencyOptimizationResults.get(curativePerimeter.getRaOptimisationState()), Set.of(curativePerimeter.getRaOptimisationState()), unit, relativePositiveMargins, numberOfLoggedElements)
                     )
                 );
         });

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/CurativeOptimizationPerimeter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/CurativeOptimizationPerimeter.java
@@ -62,7 +62,9 @@ public class CurativeOptimizationPerimeter extends AbstractOptimizationPerimeter
             availableRangeActions);
     }
 
-    public static CurativeOptimizationPerimeter buildForStates(State curativeState, Set<State> allMonitoredStates, Crac crac, Set<RangeAction<?>> rangeActions, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
+    public static CurativeOptimizationPerimeter buildForStates(State curativeState, Set<State> allMonitoredStates, Crac crac, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
+        Set<RangeAction<?>> rangeActions = crac.getRangeActions();
+
         Set<State> filteredStates = allMonitoredStates.stream()
             .filter(state -> !prePerimeterResult.getSensitivityStatus(state).equals(ComputationStatus.FAILURE))
             .collect(Collectors.toSet());

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/CurativeOptimizationPerimeter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/CurativeOptimizationPerimeter.java
@@ -12,6 +12,7 @@ import com.powsybl.openrao.data.cracapi.State;
 import com.powsybl.openrao.data.cracapi.cnec.FlowCnec;
 import com.powsybl.openrao.data.cracapi.networkaction.NetworkAction;
 import com.powsybl.openrao.data.cracapi.rangeaction.RangeAction;
+import com.powsybl.openrao.data.raoresultapi.ComputationStatus;
 import com.powsybl.openrao.raoapi.parameters.RaoParameters;
 import com.powsybl.openrao.searchtreerao.commons.RaoUtil;
 import com.powsybl.openrao.searchtreerao.result.api.PrePerimeterResult;
@@ -55,6 +56,35 @@ public class CurativeOptimizationPerimeter extends AbstractOptimizationPerimeter
         removeAlignedRangeActionsWithDifferentInitialSetpoints(availableRangeActions, prePerimeterResult);
 
         return new CurativeOptimizationPerimeter(curativeState,
+            flowCnecs,
+            loopFlowCnecs,
+            availableNetworkActions,
+            availableRangeActions);
+    }
+
+    public static CurativeOptimizationPerimeter buildForStates(State curativeState, Set<State> allMonitoredStates, Crac crac, Set<RangeAction<?>> rangeActions, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
+        Set<State> filteredStates = allMonitoredStates.stream()
+            .filter(state -> !prePerimeterResult.getSensitivityStatus(state).equals(ComputationStatus.FAILURE))
+            .collect(Collectors.toSet());
+
+        Set<FlowCnec> flowCnecs = crac.getFlowCnecs().stream()
+            .filter(flowCnec -> filteredStates.contains(flowCnec.getState()))
+            .collect(Collectors.toSet());
+
+        Set<FlowCnec> loopFlowCnecs = AbstractOptimizationPerimeter.getLoopFlowCnecs(flowCnecs, raoParameters, network);
+
+        Set<NetworkAction> availableNetworkActions = crac.getNetworkActions().stream()
+            .filter(ra -> RaoUtil.isRemedialActionAvailable(ra, curativeState, prePerimeterResult, flowCnecs, network, raoParameters))
+            .collect(Collectors.toSet());
+
+        Set<RangeAction<?>> availableRangeActions = rangeActions.stream()
+            .filter(ra -> RaoUtil.isRemedialActionAvailable(ra, curativeState, prePerimeterResult, flowCnecs, network, raoParameters))
+            .filter(ra -> AbstractOptimizationPerimeter.doesPrePerimeterSetpointRespectRange(ra, prePerimeterResult))
+            .collect(Collectors.toSet());
+        removeAlignedRangeActionsWithDifferentInitialSetpoints(availableRangeActions, prePerimeterResult);
+
+        return new CurativeOptimizationPerimeter(
+            curativeState,
             flowCnecs,
             loopFlowCnecs,
             availableNetworkActions,

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/CurativeOptimizationPerimeter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/CurativeOptimizationPerimeter.java
@@ -63,7 +63,7 @@ public class CurativeOptimizationPerimeter extends AbstractOptimizationPerimeter
     }
 
     public static CurativeOptimizationPerimeter buildForStates(State curativeState, Set<State> allMonitoredStates, Crac crac, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
-        Set<RangeAction<?>> rangeActions = crac.getRangeActions();
+        Set<RangeAction<?>> rangeActions = crac.getPotentiallyAvailableRangeActions(curativeState);
 
         Set<State> filteredStates = allMonitoredStates.stream()
             .filter(state -> !prePerimeterResult.getSensitivityStatus(state).equals(ComputationStatus.FAILURE))

--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/PreventiveOptimizationPerimeter.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/commons/optimizationperimeters/PreventiveOptimizationPerimeter.java
@@ -41,18 +41,20 @@ public class PreventiveOptimizationPerimeter extends AbstractOptimizationPerimet
     }
 
     public static PreventiveOptimizationPerimeter buildFromBasecaseScenario(Perimeter preventivePerimeter, Crac crac, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
-        return buildForStates(preventivePerimeter.getRaOptimisationState(), preventivePerimeter.getAllStates(), crac, crac.getRangeActions(), network, raoParameters, prePerimeterResult);
+        return buildForStates(preventivePerimeter.getRaOptimisationState(), preventivePerimeter.getAllStates(), crac, network, raoParameters, prePerimeterResult);
     }
 
     public static PreventiveOptimizationPerimeter buildWithPreventiveCnecsOnly(Crac crac, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
-        return buildForStates(crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), crac, crac.getRangeActions(), network, raoParameters, prePerimeterResult);
+        return buildForStates(crac.getPreventiveState(), Collections.singleton(crac.getPreventiveState()), crac, network, raoParameters, prePerimeterResult);
     }
 
     public static PreventiveOptimizationPerimeter buildWithAllCnecs(Crac crac, Set<RangeAction<?>> rangeActions, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
-        return buildForStates(crac.getPreventiveState(), crac.getStates(), crac, rangeActions, network, raoParameters, prePerimeterResult);
+        return buildForStates(crac.getPreventiveState(), crac.getStates(), crac, network, raoParameters, prePerimeterResult);
     }
 
-    public static PreventiveOptimizationPerimeter buildForStates(State preventiveState, Set<State> allMonitoredStates, Crac crac, Set<RangeAction<?>> rangeActions, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
+    public static PreventiveOptimizationPerimeter buildForStates(State preventiveState, Set<State> allMonitoredStates, Crac crac, Network network, RaoParameters raoParameters, PrePerimeterResult prePerimeterResult) {
+        Set<RangeAction<?>> rangeActions = crac.getRangeActions();
+
         Set<State> filteredStates = allMonitoredStates.stream()
             .filter(state -> !prePerimeterResult.getSensitivityStatus(state).equals(ComputationStatus.FAILURE))
             .collect(Collectors.toSet());

--- a/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/castor/algorithm/PerimeterTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/castor/algorithm/PerimeterTest.java
@@ -19,7 +19,6 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * @author Peter Mitri {@literal <peter.mitri at rte-france.com>}
@@ -55,7 +54,6 @@ class PerimeterTest {
     void testConstructor() {
         Perimeter preventivePerimeter = new Perimeter(basecaseState, Set.of(otherState1, otherState2));
         assertEquals(basecaseState, preventivePerimeter.getRaOptimisationState());
-        assertEquals(Set.of(otherState1, otherState2), preventivePerimeter.getCnecStates());
         assertEquals(Set.of(basecaseState, otherState1, otherState2), preventivePerimeter.getAllStates());
     }
 
@@ -63,12 +61,10 @@ class PerimeterTest {
     void testConstructor2() {
         Perimeter preventivePerimeter = new Perimeter(basecaseState, Set.of());
         assertEquals(basecaseState, preventivePerimeter.getRaOptimisationState());
-        assertEquals(Set.of(), preventivePerimeter.getCnecStates());
         assertEquals(Set.of(basecaseState), preventivePerimeter.getAllStates());
 
         preventivePerimeter = new Perimeter(basecaseState, null);
         assertEquals(basecaseState, preventivePerimeter.getRaOptimisationState());
-        assertEquals(Set.of(), preventivePerimeter.getCnecStates());
         assertEquals(Set.of(basecaseState), preventivePerimeter.getAllStates());
     }
 
@@ -89,25 +85,25 @@ class PerimeterTest {
     @Test
     void testAddOtherState() {
         Perimeter preventivePerimeter = new Perimeter(basecaseState, null);
-        assertEquals(Set.of(), preventivePerimeter.getCnecStates());
+        assertEquals(Set.of(basecaseState), preventivePerimeter.getAllStates());
         preventivePerimeter.addOtherState(otherState1);
-        assertEquals(Set.of(otherState1), preventivePerimeter.getCnecStates());
+        assertEquals(Set.of(basecaseState, otherState1), preventivePerimeter.getAllStates());
         preventivePerimeter.addOtherState(otherState2);
-        assertEquals(Set.of(otherState1, otherState2), preventivePerimeter.getCnecStates());
+        assertEquals(Set.of(basecaseState, otherState1, otherState2), preventivePerimeter.getAllStates());
         preventivePerimeter.addOtherState(otherState2);
-        assertEquals(Set.of(otherState1, otherState2), preventivePerimeter.getCnecStates());
+        assertEquals(Set.of(basecaseState, otherState1, otherState2), preventivePerimeter.getAllStates());
     }
 
     @Test
     void testAddRemedialActionStateToCnecsStates1() {
         Perimeter preventivePerimeter = new Perimeter(basecaseState, new HashSet<>());
         preventivePerimeter.addOtherState(basecaseState);
-        assertTrue(preventivePerimeter.getCnecStates().isEmpty());
+        assertEquals(Set.of(basecaseState), preventivePerimeter.getAllStates());
     }
 
     @Test
     void testAddRemedialActionStateToCnecsStates2() {
         Perimeter preventivePerimeter = new Perimeter(basecaseState, Set.of(basecaseState));
-        assertTrue(preventivePerimeter.getCnecStates().isEmpty());
+        assertEquals(Set.of(basecaseState), preventivePerimeter.getAllStates());
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/castor/algorithm/StateTreeTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/castor/algorithm/StateTreeTest.java
@@ -89,7 +89,7 @@ class StateTreeTest {
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
         assertEquals(1, contingencyScenario.getCurativePerimeters().size());
         assertEquals(curativeState2, contingencyScenario.getCurativePerimeters().get(0).getRaOptimisationState());
-        assertTrue(contingencyScenario.getCurativePerimeters().get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(curativeState2), contingencyScenario.getCurativePerimeters().get(0).getAllStates());
 
         assertEquals(1, stateTree.getOperatorsNotSharingCras().size());
         assertEquals("operator2", stateTree.getOperatorsNotSharingCras().iterator().next());
@@ -173,7 +173,6 @@ class StateTreeTest {
         Perimeter preventivePerimeter = stateTree.getBasecaseScenario();
         assertNotNull(preventivePerimeter);
         assertEquals(crac.getPreventiveState(), preventivePerimeter.getRaOptimisationState());
-        assertEquals(6, preventivePerimeter.getCnecStates().size());
         assertEquals(7, preventivePerimeter.getAllStates().size());
     }
 
@@ -196,7 +195,7 @@ class StateTreeTest {
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
         assertEquals(1, contingencyScenario.getCurativePerimeters().size());
         assertEquals(crac.getState("contingency-1", curativeInstant), contingencyScenario.getCurativePerimeters().get(0).getRaOptimisationState());
-        assertTrue(contingencyScenario.getCurativePerimeters().get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(crac.getState("contingency-1", curativeInstant)), contingencyScenario.getCurativePerimeters().get(0).getAllStates());
     }
 
     @Test
@@ -372,7 +371,7 @@ class StateTreeTest {
         assertEquals(Optional.empty(), contingencyScenario.getAutomatonState());
         assertEquals(1, contingencyScenario.getCurativePerimeters().size());
         assertEquals(curativeState1, contingencyScenario.getCurativePerimeters().get(0).getRaOptimisationState());
-        assertTrue(contingencyScenario.getCurativePerimeters().get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(curativeState1), contingencyScenario.getCurativePerimeters().get(0).getAllStates());
     }
 
     @Test
@@ -394,7 +393,7 @@ class StateTreeTest {
         ContingencyScenario contingencyScenario = stateTree.getContingencyScenarios().iterator().next();
         assertEquals(1, contingencyScenario.getCurativePerimeters().size());
         assertEquals(curativeState1, contingencyScenario.getCurativePerimeters().get(0).getRaOptimisationState());
-        assertTrue(contingencyScenario.getCurativePerimeters().get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(curativeState1), contingencyScenario.getCurativePerimeters().get(0).getAllStates());
 
         // 4.3 Both AUTO and CURATIVE exist, only CURATIVE has RAs
         setUpCustomCracWithAutoInstant(true, false, true, true);
@@ -406,7 +405,7 @@ class StateTreeTest {
         assertEquals(Optional.empty(), contingencyScenario.getAutomatonState());
         assertEquals(1, contingencyScenario.getCurativePerimeters().size());
         assertEquals(curativeState1, contingencyScenario.getCurativePerimeters().get(0).getRaOptimisationState());
-        assertTrue(contingencyScenario.getCurativePerimeters().get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(curativeState1), contingencyScenario.getCurativePerimeters().get(0).getAllStates());
 
         // 4.4 Both AUTO and CURATIVE exist and have RAs
         setUpCustomCracWithAutoInstant(true, true, true, true);
@@ -418,7 +417,7 @@ class StateTreeTest {
         assertEquals(Optional.of(autoState), contingencyScenario.getAutomatonState());
         assertEquals(1, contingencyScenario.getCurativePerimeters().size());
         assertEquals(curativeState1, contingencyScenario.getCurativePerimeters().get(0).getRaOptimisationState());
-        assertTrue(contingencyScenario.getCurativePerimeters().get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(curativeState1), contingencyScenario.getCurativePerimeters().get(0).getAllStates());
     }
 
     @Test
@@ -436,7 +435,7 @@ class StateTreeTest {
         assertEquals(Optional.of(autoState), contingencyScenario.getAutomatonState());
         assertEquals(1, contingencyScenario.getCurativePerimeters().size());
         assertEquals(curativeState1, contingencyScenario.getCurativePerimeters().get(0).getRaOptimisationState());
-        assertTrue(contingencyScenario.getCurativePerimeters().get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(curativeState1), contingencyScenario.getCurativePerimeters().get(0).getAllStates());
     }
 
     @Test
@@ -481,7 +480,7 @@ class StateTreeTest {
 
         List<Perimeter> curativePerimeters;
         ContingencyScenario contingencyScenario;
-        List<State> otherStates;
+        List<State> allStates;
 
         contingencyScenario = contingencyScenarios.get(0);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -493,9 +492,9 @@ class StateTreeTest {
             .toList();
         assertEquals(2, curativePerimeters.size());
         assertEquals("co-01 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
         assertEquals("co-01 - curative2", curativePerimeters.get(1).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(1).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(1).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(1);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -507,9 +506,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-02 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-02 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-02 - curative1", allStates.get(0).getId());
+        assertEquals("co-02 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(2);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -521,7 +521,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-03 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-03", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(3);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -533,7 +533,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-04 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-04", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(4);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -545,7 +545,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-05 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-05", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(5);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -557,7 +557,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-09 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-09", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(6);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -569,9 +569,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-10 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-10 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-10 - curative1", allStates.get(0).getId());
+        assertEquals("co-10 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(7);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -583,9 +584,9 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-13 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-13", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
-        assertEquals(6, stateTree.getBasecaseScenario().getCnecStates().size());
+        assertEquals(7, stateTree.getBasecaseScenario().getAllStates().size());
         assertCurativeStateInBaseCase(stateTree, multipleCurativeInstantsCrac, "co-05", "curative1");
         assertCurativeStateInBaseCase(stateTree, multipleCurativeInstantsCrac, "co-06", "curative1");
         assertCurativeStateInBaseCase(stateTree, multipleCurativeInstantsCrac, "co-06", "curative2");
@@ -606,7 +607,7 @@ class StateTreeTest {
 
         List<Perimeter> curativePerimeters;
         ContingencyScenario contingencyScenario;
-        List<State> otherStates;
+        List<State> allStates;
 
         contingencyScenario = contingencyScenarios.get(0);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -618,9 +619,9 @@ class StateTreeTest {
             .toList();
         assertEquals(2, curativePerimeters.size());
         assertEquals("co-01 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
         assertEquals("co-01 - curative2", curativePerimeters.get(1).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(1).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(1).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(1);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -632,9 +633,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-02 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-02 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-02 - curative1", allStates.get(0).getId());
+        assertEquals("co-02 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(2);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -646,7 +648,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-03 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-03", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(3);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -658,7 +660,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-04 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-04", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(4);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -670,7 +672,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-05 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-05", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(5);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -682,7 +684,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-09 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-09", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(6);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -694,9 +696,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-10 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-10 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-10 - curative1", allStates.get(0).getId());
+        assertEquals("co-10 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(7);
         assertTrue(contingencyScenario.getAutomatonState().isEmpty());
@@ -708,9 +711,9 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-13 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-13", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
-        assertEquals(22, stateTree.getBasecaseScenario().getCnecStates().size());
+        assertEquals(23, stateTree.getBasecaseScenario().getAllStates().size());
         assertCurativeStateInBaseCase(stateTree, multipleCurativeInstantsCrac, "co-05", "curative1");
         assertCurativeStateInBaseCase(stateTree, multipleCurativeInstantsCrac, "co-06", "curative1");
         assertCurativeStateInBaseCase(stateTree, multipleCurativeInstantsCrac, "co-06", "curative2");
@@ -747,7 +750,7 @@ class StateTreeTest {
 
         List<Perimeter> curativePerimeters;
         ContingencyScenario contingencyScenario;
-        List<State> otherStates;
+        List<State> allStates;
 
         contingencyScenario = contingencyScenarios.get(0);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -760,9 +763,9 @@ class StateTreeTest {
             .toList();
         assertEquals(2, curativePerimeters.size());
         assertEquals("co-01 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
         assertEquals("co-01 - curative2", curativePerimeters.get(1).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(1).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(1).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(1);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -775,9 +778,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-02 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-02 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-02 - curative1", allStates.get(0).getId());
+        assertEquals("co-02 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(2);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -790,7 +794,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-03 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-03", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(3);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -803,7 +807,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-04 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-04", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(4);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -816,9 +820,9 @@ class StateTreeTest {
             .toList();
         assertEquals(2, curativePerimeters.size());
         assertEquals("co-05 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-05", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
         assertEquals("co-05 - curative2", curativePerimeters.get(1).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(1).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-05", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(1).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(5);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -831,9 +835,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-06 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-06 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-06 - curative1", allStates.get(0).getId());
+        assertEquals("co-06 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(6);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -846,7 +851,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-07 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-07", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(7);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -859,7 +864,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-08 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-08", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(8);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -872,7 +877,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-09 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-09", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(9);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -885,9 +890,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-10 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-10 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-10 - curative1", allStates.get(0).getId());
+        assertEquals("co-10 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(10);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -900,9 +906,9 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-13 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-13", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
-        assertEquals(0, stateTree.getBasecaseScenario().getCnecStates().size());
+        assertEquals(1, stateTree.getBasecaseScenario().getAllStates().size());
     }
 
     @Test
@@ -918,7 +924,7 @@ class StateTreeTest {
 
         List<Perimeter> curativePerimeters;
         ContingencyScenario contingencyScenario;
-        List<State> otherStates;
+        List<State> allStates;
 
         contingencyScenario = contingencyScenarios.get(0);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -931,9 +937,9 @@ class StateTreeTest {
             .toList();
         assertEquals(2, curativePerimeters.size());
         assertEquals("co-01 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
         assertEquals("co-01 - curative2", curativePerimeters.get(1).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(1).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-01", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(1).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(1);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -946,9 +952,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-02 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-02 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-02 - curative1", allStates.get(0).getId());
+        assertEquals("co-02 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(2);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -961,7 +968,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-03 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-03", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(3);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -974,7 +981,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-04 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-04", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(4);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -987,9 +994,9 @@ class StateTreeTest {
             .toList();
         assertEquals(2, curativePerimeters.size());
         assertEquals("co-05 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-05", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
         assertEquals("co-05 - curative2", curativePerimeters.get(1).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-05", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(1).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(5);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1002,9 +1009,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-06 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-06 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-06 - curative1", allStates.get(0).getId());
+        assertEquals("co-06 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(6);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1017,7 +1025,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-07 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-07", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(7);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1030,7 +1038,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-08 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-08", multipleCurativeInstantsCrac.getInstant("curative1"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(8);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1043,7 +1051,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-09 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-09", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(9);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1056,9 +1064,10 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-10 - curative1", curativePerimeters.get(0).getRaOptimisationState().getId());
-        otherStates = curativePerimeters.get(0).getCnecStates().stream().toList();
-        assertEquals(1, otherStates.size());
-        assertEquals("co-10 - curative2", otherStates.get(0).getId());
+        allStates = curativePerimeters.get(0).getAllStates().stream().sorted(Comparator.comparing(State::getId)).toList();
+        assertEquals(2, allStates.size());
+        assertEquals("co-10 - curative1", allStates.get(0).getId());
+        assertEquals("co-10 - curative2", allStates.get(1).getId());
 
         contingencyScenario = contingencyScenarios.get(10);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1083,7 +1092,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-13 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-13", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(13);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1096,7 +1105,7 @@ class StateTreeTest {
             .toList();
         assertEquals(1, curativePerimeters.size());
         assertEquals("co-14 - curative2", curativePerimeters.get(0).getRaOptimisationState().getId());
-        assertTrue(curativePerimeters.get(0).getCnecStates().isEmpty());
+        assertEquals(Set.of(multipleCurativeInstantsCrac.getState("co-14", multipleCurativeInstantsCrac.getInstant("curative2"))), curativePerimeters.get(0).getAllStates());
 
         contingencyScenario = contingencyScenarios.get(14);
         assertTrue(contingencyScenario.getAutomatonState().isPresent());
@@ -1110,7 +1119,7 @@ class StateTreeTest {
         assertEquals("co-16", contingencyScenario.getContingency().getId());
         assertTrue(contingencyScenario.getCurativePerimeters().isEmpty());
 
-        assertEquals(0, stateTree.getBasecaseScenario().getCnecStates().size());
+        assertEquals(1, stateTree.getBasecaseScenario().getAllStates().size());
     }
 
     private static Crac createCommonMultipleCurativeInstantsCrac() {
@@ -1254,6 +1263,6 @@ class StateTreeTest {
     }
 
     private static void assertCurativeStateInBaseCase(StateTree stateTree, Crac crac, String contingencyId, String instantId) {
-        assertTrue(stateTree.getBasecaseScenario().getCnecStates().contains(crac.getState(contingencyId, crac.getInstant(instantId))));
+        assertTrue(stateTree.getBasecaseScenario().getAllStates().contains(crac.getState(contingencyId, crac.getInstant(instantId))));
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
Previously, all the curative states were optimized which was not efficient. Now, only the perimeters are optimized. Besides, a systematic sensitivity computation between curative perimeters was added.