### PR TITLE
remove extra Voltage monitoring end log

### DIFF
--- a/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/VoltageMonitoring.java
@@ -70,7 +70,6 @@ public class VoltageMonitoring {
         if (crac.getVoltageCnecs().isEmpty()) {
             BUSINESS_WARNS.warn("No VoltageCnecs defined.");
             stateSpecificResults.add(new VoltageMonitoringResult(Collections.emptyMap(), Collections.emptyMap(), VoltageMonitoringResult.Status.SECURE));
-            BUSINESS_LOGS.info(VOLTAGE_MONITORING_END);
             return assembleVoltageMonitoringResults();
         }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When no voltage cnecs exist, two voltage monitroing end logs are logged


**What is the new behavior (if this is a feature change)?**
Only the second one is logged


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
