### PR TITLE
check only FlowCnecs in StateTree

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/StateTree.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/castor/algorithm/StateTree.java
@@ -196,7 +196,7 @@ public class StateTree {
     }
 
     private boolean anyCnec(Crac crac, State state) {
-        return !crac.getCnecs(state).isEmpty();
+        return !crac.getFlowCnecs(state).isEmpty();
     }
 
     private static boolean anyAvailableRemedialAction(Crac crac, State state) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently the StateTree checks for all kind of cnecs when it's being built. This can cause issues when only voltage cnecs exist for example: we create an optimizationPerimeter with no flowCnecs, and so the sensi analysis seems to have failed because it has no flow results, and a skippedOptimizationResult is created.


**What is the new behavior (if this is a feature change)?**
We check only flowCnecs.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No