### PR TITLE
Add link to PowSyBl doc

### DIFF
--- a/docs/_templates/sidebar/brand.html
+++ b/docs/_templates/sidebar/brand.html
@@ -1,0 +1,25 @@
+{#-
+Overrides furo's brand.html to customize links:
+- The logo links to a custom page (set sidebar_logo_href option in html_context)
+- The title links to the subproject's main page
+-#}
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{% if sidebar_logo_href %} {{ sidebar_logo_href }} {% else %} {{ pathto(master_doc) }} {% endif %}">
+    {% block brand_content %}
+    {%- if logo_url %}
+    <div class="sidebar-logo-container">
+        <img class="sidebar-logo" src="{{ logo_url }}" alt="Logo"/>
+    </div>
+    {%- endif %}
+    {%- if theme_light_logo and theme_dark_logo %}
+    <div class="sidebar-logo-container">
+        <img class="sidebar-logo only-light" src="{{ pathto('_static/' + theme_light_logo, 1) }}" alt="Light Logo"/>
+        <img class="sidebar-logo only-dark" src="{{ pathto('_static/' + theme_dark_logo, 1) }}" alt="Dark Logo"/>
+    </div>
+    {%- endif %}
+    {% endblock brand_content %}
+</a>
+{% if not theme_sidebar_hide_name %}
+<a class="sidebar-brand{% if logo %} centered{% endif %}" href="{{ pathto(master_doc) }}">
+    <span class="sidebar-brand-text">{{ docstitle if docstitle else project }}</span>
+</a>
+{%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -68,6 +68,10 @@ html_short_title = 'Open RAO'
 html_logo = '_static/logos/logo_lfe_powsybl.svg'
 html_favicon = "_static/favicon.ico"
 
+html_context = {
+    "sidebar_logo_href": "https://powsybl.readthedocs.org"
+}
+
 html_theme_options = {
     "icon_links": [
         {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,8 @@ html_logo = '_static/logos/logo_lfe_powsybl.svg'
 html_favicon = "_static/favicon.ico"
 
 html_context = {
-    "sidebar_logo_href": "https://powsybl.readthedocs.org"
+    # TODO : replace next option with "https://powsybl.readthedocs.org" when website is published
+    "sidebar_logo_href": "https://www.powsybl.org/"
 }
 
 html_theme_options = {


### PR DESCRIPTION
In documentation, this PR allows linking:
- The PowSyBl logo to https://powsybl.readthedocs.org (temporarily to powsybl.org since powsybl.readthedocs is not published yet)
- The "Open RAO" title to the doc's main page

outcome can be previewed here: https://powsybl--950.org.readthedocs.build/projects/openrao/en/950/