### PR TITLE
Fix OnFlowConstraintInCountry with contingency interpretation in RAO

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/OnFlowConstraintInCountryImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/OnFlowConstraintInCountryImpl.java
@@ -47,6 +47,9 @@ public class OnFlowConstraintInCountryImpl extends AbstractUsageRule implements 
 
     @Override
     public UsageMethod getUsageMethod(State state) {
+        if (contingency.isPresent() && !contingency.get().equals(state.getContingency().orElse(null))) {
+            return UsageMethod.UNDEFINED;
+        }
         return state.getInstant().equals(instant) ? usageMethod : UsageMethod.UNDEFINED;
     }
 

--- a/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/OnFlowConstraintInCountryImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/OnFlowConstraintInCountryImplTest.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.openrao.data.cracimpl;
 
+import com.powsybl.contingency.Contingency;
 import com.powsybl.openrao.data.cracapi.Instant;
 import com.powsybl.openrao.data.cracapi.InstantKind;
 import com.powsybl.openrao.data.cracapi.State;
@@ -72,5 +73,42 @@ class OnFlowConstraintInCountryImplTest {
         onFlowConstraint2 = new OnFlowConstraintInCountryImpl(UsageMethod.AVAILABLE, PREVENTIVE_INSTANT, Optional.empty(), Country.FR);
         assertNotEquals(onFlowConstraint1, onFlowConstraint2);
         assertNotEquals(onFlowConstraint1.hashCode(), onFlowConstraint2.hashCode());
+    }
+
+    @Test
+    void testGetUsageMethodWithContringency() {
+        Contingency contingency1 = Mockito.mock(Contingency.class);
+        Contingency contingency2 = Mockito.mock(Contingency.class);
+
+        State stateAuto1 = new PostContingencyState(contingency1, AUTO_INSTANT);
+        State stateCur1 = new PostContingencyState(contingency1, CURATIVE_INSTANT);
+        State stateAuto2 = new PostContingencyState(contingency2, AUTO_INSTANT);
+        State stateCur2 = new PostContingencyState(contingency2, CURATIVE_INSTANT);
+
+        OnFlowConstraintInCountry ur;
+
+        ur = new OnFlowConstraintInCountryImpl(UsageMethod.AVAILABLE, AUTO_INSTANT, Optional.of(contingency1), Country.ES);
+        assertEquals(UsageMethod.AVAILABLE, ur.getUsageMethod(stateAuto1));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateCur1));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateAuto2));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateCur2));
+
+        ur = new OnFlowConstraintInCountryImpl(UsageMethod.AVAILABLE, AUTO_INSTANT, Optional.empty(), Country.ES);
+        assertEquals(UsageMethod.AVAILABLE, ur.getUsageMethod(stateAuto1));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateCur1));
+        assertEquals(UsageMethod.AVAILABLE, ur.getUsageMethod(stateAuto2));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateCur2));
+
+        ur = new OnFlowConstraintInCountryImpl(UsageMethod.AVAILABLE, CURATIVE_INSTANT, Optional.of(contingency1), Country.ES);
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateAuto1));
+        assertEquals(UsageMethod.AVAILABLE, ur.getUsageMethod(stateCur1));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateAuto2));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateCur2));
+
+        ur = new OnFlowConstraintInCountryImpl(UsageMethod.AVAILABLE, CURATIVE_INSTANT, Optional.empty(), Country.ES);
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateAuto1));
+        assertEquals(UsageMethod.AVAILABLE, ur.getUsageMethod(stateCur1));
+        assertEquals(UsageMethod.UNDEFINED, ur.getUsageMethod(stateAuto2));
+        assertEquals(UsageMethod.AVAILABLE, ur.getUsageMethod(stateCur2));
     }
 }

--- a/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/commons/RaoUtilTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/commons/RaoUtilTest.java
@@ -340,6 +340,7 @@ class RaoUtilTest {
         Instant curativeInstant = crac.getInstant(CURATIVE_INSTANT_ID);
         State optimizedState = Mockito.mock(State.class);
         when(optimizedState.getInstant()).thenReturn(curativeInstant);
+        when(optimizedState.getContingency()).thenReturn(Optional.of(crac.getContingency("Contingency FR1 FR3")));
 
         FlowCnec cnecCont1 = crac.getFlowCnec("cnec1stateCurativeContingency1");
         FlowCnec cnecCont2 = crac.getFlowCnec("cnec2stateCurativeContingency2");


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
PR https://github.com/powsybl/powsybl-open-rao/pull/987 introduced a new way of filtering on contingency before applying an RA that is available after a constraint in a given country. The new behavior made the usage rule be validated against constraints on CNECs linked to that contingency.  
However, no check was made as to what state the RA is being applied in. Thus, if applying in one state while having a flow result containting CNECs from other states, the RA can be applied after a contingency it was not meant for.


**What is the new behavior (if this is a feature change)?**
Now the RA is only available if the state of application corresponds to its contingency.