### PR TITLE
Fix bug injection setpoint shunt compensator can be applied

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/InjectionSetpointImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/InjectionSetpointImpl.java
@@ -64,7 +64,7 @@ public final class InjectionSetpointImpl implements InjectionSetpoint {
     public boolean canBeApplied(Network network) {
         Identifiable<?> identifiable = network.getIdentifiable(networkElement.getId());
         if (identifiable instanceof ShuntCompensator shuntCompensator) {
-            return shuntCompensator.getMaximumSectionCount() < setpoint;
+            return setpoint <= shuntCompensator.getMaximumSectionCount();
         }
         return true;
     }

--- a/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/InjectionSetpointImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/InjectionSetpointImplTest.java
@@ -164,6 +164,39 @@ class InjectionSetpointImplTest {
     }
 
     @Test
+    void canNotBeAppliedOnShuntCompensator() {
+        Network network = NetworkImportsUtil.import12NodesNetwork();
+        NetworkImportsUtil.addShuntCompensator(network);
+        InjectionSetpointImpl shuntCompensatorSetpoint = new InjectionSetpointImpl(
+            new NetworkElementImpl("SC1"),
+            3, Unit.SECTION_COUNT);
+        assertEquals(2, network.getShuntCompensator("SC1").getMaximumSectionCount());
+        assertFalse(shuntCompensatorSetpoint.canBeApplied(network)); // max is 2 while setpoint is 3
+    }
+
+    @Test
+    void canBeAppliedOnShuntCompensator() {
+        Network network = NetworkImportsUtil.import12NodesNetwork();
+        NetworkImportsUtil.addShuntCompensator(network);
+        InjectionSetpointImpl shuntCompensatorSetpoint = new InjectionSetpointImpl(
+            new NetworkElementImpl("SC1"),
+            1, Unit.SECTION_COUNT);
+        assertEquals(2, network.getShuntCompensator("SC1").getMaximumSectionCount());
+        assertTrue(shuntCompensatorSetpoint.canBeApplied(network)); // max is 2 while setpoint is 1
+    }
+
+    @Test
+    void canMaxBeAppliedOnShuntCompensator() {
+        Network network = NetworkImportsUtil.import12NodesNetwork();
+        NetworkImportsUtil.addShuntCompensator(network);
+        InjectionSetpointImpl shuntCompensatorSetpoint = new InjectionSetpointImpl(
+            new NetworkElementImpl("SC1"),
+            2, Unit.SECTION_COUNT);
+        assertEquals(2, network.getShuntCompensator("SC1").getMaximumSectionCount());
+        assertTrue(shuntCompensatorSetpoint.canBeApplied(network)); // max is 2 while setpoint is 2
+    }
+
+    @Test
     void getUnit() {
         InjectionSetpointImpl dummy = new InjectionSetpointImpl(
                 new NetworkElementImpl("wrong_name"),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Injection set point on shunt compensator cannot be applied (called by network action apply) if the setpoint is equal or below the max section count of the shunt compensator.


**What is the new behavior (if this is a feature change)?**
Injection set point on shunt compensator cannot be applied (called by network action apply) if the setpoint is strictly above the max section count of the shunt compensator.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
