### PR TITLE
Bump powsybl-core to 6.4.1, open-loadflow to 1.12.2 and entsoe to 2.10.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,9 +116,9 @@
         <maven.source.version>3.2.1</maven.source.version>
         <maven.templating.version>1.0.0</maven.templating.version>
         <mockito.inline.version>5.2.0</mockito.inline.version>
-        <powsybl.core.version>6.4.0</powsybl.core.version>
-        <powsybl.entsoe.version>2.10.0</powsybl.entsoe.version>
-        <powsybl.openloadflow.version>1.12.1</powsybl.openloadflow.version>
+        <powsybl.core.version>6.4.1</powsybl.core.version>
+        <powsybl.entsoe.version>2.10.1</powsybl.entsoe.version>
+        <powsybl.openloadflow.version>1.12.2</powsybl.openloadflow.version>
         <slf4j.version>1.7.36</slf4j.version>
         <xmlunit.core.version>2.8.1</xmlunit.core.version>
     </properties>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependency update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`powsybl-open-rao` uses:
- `powsybl-core` 6.4.0;
- `powsybl-open-loadflow` 1.12.1;
- `powsybl-entsoe` 2.10.0.

**What is the new behavior (if this is a feature change)?**

`powsybl-open-rao` uses:
- `powsybl-core` **6.4.1**;
- `powsybl-open-loadflow` **1.12.2**;
- `powsybl-entsoe` **2.10.1**.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
