### PR TITLE
FbConstraintImporter : remove unused flowBasedDocumentVersion variable in importNativeCrac method

### DIFF
--- a/data/crac-creation/crac-creator-fb-constraint/src/main/java/com/powsybl/openrao/data/craccreation/creator/fbconstraint/FbConstraintImporter.java
+++ b/data/crac-creation/crac-creator-fb-constraint/src/main/java/com/powsybl/openrao/data/craccreation/creator/fbconstraint/FbConstraintImporter.java
@@ -59,7 +59,6 @@ public class FbConstraintImporter implements Importer<FbConstraintCreationContex
     private FlowBasedConstraintDocument importNativeCrac(InputStream inputStream) {
         try {
             byte[] bytes = getBytesFromInputStream(inputStream);
-            int flowBasedDocumentVersion = flowBasedDocumentVersion(new ByteArrayInputStream(bytes));
             JAXBContext jaxbContext = JAXBContext.newInstance(FlowBasedConstraintDocument.class);
             Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
             FlowBasedConstraintDocument document = (FlowBasedConstraintDocument) jaxbUnmarshaller.unmarshal(new ByteArrayInputStream(bytes));


### PR DESCRIPTION

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
