### PR TITLE
Fix raoResult.isSecure(ANGLE) and raoResult.isSecure(VOLTAGE)

### DIFF
--- a/monitoring/angle-monitoring/src/main/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoring.java
+++ b/monitoring/angle-monitoring/src/main/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoring.java
@@ -92,7 +92,11 @@ public class RaoResultWithAngleMonitoring extends RaoResultClone {
     public boolean isSecure(Instant instant, PhysicalParameter... u) {
         List<PhysicalParameter> physicalParameters = new ArrayList<>(Stream.of(u).sorted().toList());
         if (physicalParameters.remove(PhysicalParameter.ANGLE)) {
-            return raoResult.isSecure(instant, physicalParameters.toArray(new PhysicalParameter[0])) && angleMonitoringResult.isSecure();
+            if (physicalParameters.isEmpty()) {
+                return angleMonitoringResult.isSecure();
+            } else {
+                return raoResult.isSecure(instant, physicalParameters.toArray(new PhysicalParameter[0])) && angleMonitoringResult.isSecure();
+            }
         } else {
             return raoResult.isSecure(instant, u);
         }
@@ -102,7 +106,11 @@ public class RaoResultWithAngleMonitoring extends RaoResultClone {
     public boolean isSecure(PhysicalParameter... u) {
         List<PhysicalParameter> physicalParameters = new ArrayList<>(Stream.of(u).sorted().toList());
         if (physicalParameters.remove(PhysicalParameter.ANGLE)) {
-            return raoResult.isSecure(physicalParameters.toArray(new PhysicalParameter[0])) && angleMonitoringResult.isSecure();
+            if (physicalParameters.isEmpty()) {
+                return angleMonitoringResult.isSecure();
+            } else {
+                return raoResult.isSecure(physicalParameters.toArray(new PhysicalParameter[0])) && angleMonitoringResult.isSecure();
+            }
         } else {
             return raoResult.isSecure(u);
         }

--- a/monitoring/angle-monitoring/src/test/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoringTest.java
+++ b/monitoring/angle-monitoring/src/test/java/com/powsybl/openrao/monitoring/anglemonitoring/RaoResultWithAngleMonitoringTest.java
@@ -88,22 +88,24 @@ class RaoResultWithAngleMonitoringTest {
     void testIsSecureWhenRaoResultAndAngleMonitoringIsSecure() {
         RaoResult raoResult = Mockito.mock(RaoResult.class);
         AngleMonitoringResult angleMonitoringResult = Mockito.mock(AngleMonitoringResult.class);
-        RaoResult raoResultWithVoltageMonitoring = new RaoResultWithAngleMonitoring(raoResult, angleMonitoringResult);
+        RaoResult raoResultWithAngleMonitoring = new RaoResultWithAngleMonitoring(raoResult, angleMonitoringResult);
         Mockito.when(raoResult.isSecure()).thenReturn(true);
         Mockito.when(angleMonitoringResult.isSecure()).thenReturn(true);
         Mockito.when(raoResult.isSecure(PhysicalParameter.FLOW)).thenReturn(true);
         Mockito.when(raoResult.isSecure(Mockito.any(Instant.class), Mockito.eq(PhysicalParameter.FLOW))).thenReturn(true);
 
-        assertTrue(raoResultWithVoltageMonitoring.isSecure());
-        assertTrue(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
-        assertTrue(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertTrue(raoResultWithAngleMonitoring.isSecure());
+        assertTrue(raoResultWithAngleMonitoring.isSecure(PhysicalParameter.ANGLE));
+        assertTrue(raoResultWithAngleMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertTrue(raoResultWithAngleMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.ANGLE));
+        assertTrue(raoResultWithAngleMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
     }
 
     @Test
     void testIsSecureWhenRaoResultAndAngleMonitoringUnsecureIfAngleNotChecked() {
         RaoResult raoResult = Mockito.mock(RaoResult.class);
         AngleMonitoringResult angleMonitoringResult = Mockito.mock(AngleMonitoringResult.class);
-        RaoResult raoResultWithVoltageMonitoring = new RaoResultWithAngleMonitoring(raoResult, angleMonitoringResult);
+        RaoResult raoResultWithAngleMonitoring = new RaoResultWithAngleMonitoring(raoResult, angleMonitoringResult);
         Mockito.when(raoResult.isSecure()).thenReturn(true);
         Mockito.when(angleMonitoringResult.isSecure()).thenReturn(false);
         Mockito.when(raoResult.isSecure(PhysicalParameter.FLOW)).thenReturn(true);
@@ -111,25 +113,29 @@ class RaoResultWithAngleMonitoringTest {
         Mockito.when(raoResult.isSecure(Mockito.any(Instant.class), Mockito.eq(PhysicalParameter.FLOW))).thenReturn(true);
         Mockito.when(raoResult.isSecure(Mockito.any(Instant.class), Mockito.eq(PhysicalParameter.FLOW), Mockito.eq(PhysicalParameter.VOLTAGE))).thenReturn(true);
 
-        assertFalse(raoResultWithVoltageMonitoring.isSecure());
-        assertFalse(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
-        assertFalse(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
-        assertTrue(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
-        assertTrue(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
+        assertFalse(raoResultWithAngleMonitoring.isSecure());
+        assertFalse(raoResultWithAngleMonitoring.isSecure(PhysicalParameter.ANGLE));
+        assertFalse(raoResultWithAngleMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertFalse(raoResultWithAngleMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.ANGLE));
+        assertFalse(raoResultWithAngleMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertTrue(raoResultWithAngleMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
+        assertTrue(raoResultWithAngleMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
     }
 
     @Test
     void testIsUnsecureWhenRaoResultIsUnsecureAndAngleMonitoringIsSecure() {
         RaoResult raoResult = Mockito.mock(RaoResult.class);
         AngleMonitoringResult angleMonitoringResult = Mockito.mock(AngleMonitoringResult.class);
-        RaoResult raoResultWithVoltageMonitoring = new RaoResultWithAngleMonitoring(raoResult, angleMonitoringResult);
+        RaoResult raoResultWithAngleMonitoring = new RaoResultWithAngleMonitoring(raoResult, angleMonitoringResult);
         Mockito.when(raoResult.isSecure()).thenReturn(false);
         Mockito.when(angleMonitoringResult.isSecure()).thenReturn(true);
         Mockito.when(raoResult.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE)).thenReturn(false);
         Mockito.when(raoResult.isSecure(Mockito.any(Instant.class), Mockito.eq(PhysicalParameter.FLOW), Mockito.eq(PhysicalParameter.ANGLE))).thenReturn(false);
 
-        assertFalse(raoResultWithVoltageMonitoring.isSecure());
-        assertFalse(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
-        assertFalse(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertFalse(raoResultWithAngleMonitoring.isSecure());
+        assertTrue(raoResultWithAngleMonitoring.isSecure(PhysicalParameter.ANGLE));
+        assertFalse(raoResultWithAngleMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
+        assertTrue(raoResultWithAngleMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.ANGLE));
+        assertFalse(raoResultWithAngleMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
     }
 }

--- a/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoring.java
+++ b/monitoring/voltage-monitoring/src/main/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoring.java
@@ -100,7 +100,11 @@ public class RaoResultWithVoltageMonitoring extends RaoResultClone {
     public boolean isSecure(Instant instant, PhysicalParameter... u) {
         List<PhysicalParameter> physicalParameters = new ArrayList<>(Stream.of(u).sorted().toList());
         if (physicalParameters.remove(PhysicalParameter.VOLTAGE)) {
-            return raoResult.isSecure(instant, physicalParameters.toArray(new PhysicalParameter[0])) && voltageMonitoringResult.isSecure();
+            if (physicalParameters.isEmpty()) {
+                return voltageMonitoringResult.isSecure();
+            } else {
+                return raoResult.isSecure(instant, physicalParameters.toArray(new PhysicalParameter[0])) && voltageMonitoringResult.isSecure();
+            }
         } else {
             return raoResult.isSecure(instant, u);
         }
@@ -110,7 +114,11 @@ public class RaoResultWithVoltageMonitoring extends RaoResultClone {
     public boolean isSecure(PhysicalParameter... u) {
         List<PhysicalParameter> physicalParameters = new ArrayList<>(Stream.of(u).sorted().toList());
         if (physicalParameters.remove(PhysicalParameter.VOLTAGE)) {
-            return raoResult.isSecure(physicalParameters.toArray(new PhysicalParameter[0])) && voltageMonitoringResult.isSecure();
+            if (physicalParameters.isEmpty()) {
+                return voltageMonitoringResult.isSecure();
+            } else {
+                return raoResult.isSecure(physicalParameters.toArray(new PhysicalParameter[0])) && voltageMonitoringResult.isSecure();
+            }
         } else {
             return raoResult.isSecure(u);
         }

--- a/monitoring/voltage-monitoring/src/test/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoringTest.java
+++ b/monitoring/voltage-monitoring/src/test/java/com/powsybl/openrao/monitoring/voltagemonitoring/RaoResultWithVoltageMonitoringTest.java
@@ -85,7 +85,9 @@ class RaoResultWithVoltageMonitoringTest {
         Mockito.when(raoResult.isSecure(Mockito.any(Instant.class), Mockito.eq(PhysicalParameter.FLOW))).thenReturn(true);
 
         assertTrue(raoResultWithVoltageMonitoring.isSecure());
+        assertTrue(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.VOLTAGE));
         assertTrue(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
+        assertTrue(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.VOLTAGE));
         assertTrue(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
     }
 
@@ -102,7 +104,9 @@ class RaoResultWithVoltageMonitoringTest {
         Mockito.when(raoResult.isSecure(Mockito.any(Instant.class), Mockito.eq(PhysicalParameter.FLOW), Mockito.eq(PhysicalParameter.ANGLE))).thenReturn(true);
 
         assertFalse(raoResultWithVoltageMonitoring.isSecure());
+        assertFalse(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.VOLTAGE));
         assertFalse(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
+        assertFalse(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.VOLTAGE));
         assertFalse(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
         assertTrue(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
         assertTrue(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.ANGLE));
@@ -119,6 +123,7 @@ class RaoResultWithVoltageMonitoringTest {
         Mockito.when(raoResult.isSecure(Mockito.any(Instant.class), Mockito.eq(PhysicalParameter.FLOW), Mockito.eq(PhysicalParameter.VOLTAGE))).thenReturn(false);
 
         assertFalse(raoResultWithVoltageMonitoring.isSecure());
+        assertTrue(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.VOLTAGE));
         assertFalse(raoResultWithVoltageMonitoring.isSecure(PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
         assertFalse(raoResultWithVoltageMonitoring.isSecure(Mockito.mock(Instant.class), PhysicalParameter.FLOW, PhysicalParameter.VOLTAGE));
     }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
When RaoResultWithAngleMonitoring is called with isSecure(ANGLE), it returns false if FLOW is unsecure, even though ANGLE is secure. This is due to the fact that it calls the underlying flowRaoResult.isSecure(physicalParams) with physicalParams being empty, which misbehaves.
Same thing happens for voltage monitoring.


**What is the new behavior (if this is a feature change)?**
The issue has been fixed by not calling the underlying raoResult.isSecure if physicalParams is empty


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
