### PR TITLE
Fix concurrent exceptions due to Map in FlowResultImpl

### DIFF
--- a/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FlowResultImpl.java
+++ b/ra-optimisation/search-tree-rao/src/main/java/com/powsybl/openrao/searchtreerao/result/impl/FlowResultImpl.java
@@ -18,8 +18,8 @@ import com.powsybl.openrao.searchtreerao.commons.RaoUtil;
 import com.powsybl.openrao.searchtreerao.result.api.FlowResult;
 import com.powsybl.openrao.sensitivityanalysis.SystematicSensitivityResult;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static java.lang.String.format;
 
@@ -32,8 +32,8 @@ public class FlowResultImpl implements FlowResult {
     private final Map<FlowCnec, Map<TwoSides, Double>> ptdfZonalSums;
     private final FlowResult fixedCommercialFlows;
     private final FlowResult fixedPtdfZonalSums;
-    private final Map<FlowCnec, Double> marginMapMW = new HashMap<>();
-    private final Map<FlowCnec, Double> marginMapA = new HashMap<>();
+    private final Map<FlowCnec, Double> marginMapMW = new ConcurrentHashMap<>();
+    private final Map<FlowCnec, Double> marginMapA = new ConcurrentHashMap<>();
 
     public FlowResultImpl(SystematicSensitivityResult systematicSensitivityResult,
                           Map<FlowCnec, Map<TwoSides, Double>> commercialFlows,


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
An exception was sometimes thrown by FlowResultImpl when getting a result from the memoization map.


**What is the new behavior (if this is a feature change)?**
The HashMap has been replaced by a ConcurrentHashMap.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
