### PR TITLE
Monitoring bug fix

### DIFF
--- a/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/FlowCnecImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/FlowCnecImpl.java
@@ -159,11 +159,7 @@ public class FlowCnecImpl extends AbstractBranchCnec<FlowCnec> implements FlowCn
         }
         Branch branch = network.getBranch(getNetworkElement().getId());
         if (getMonitoredSides().size() == 2) {
-            double power1;
-            double power2;
-            power1 = getFlow(branch, TwoSides.ONE, unit);
-            power2 = getFlow(branch, TwoSides.TWO, unit);
-            return new FlowCnecValue(power1, power2);
+            return new FlowCnecValue(getFlow(branch, TwoSides.ONE, unit), getFlow(branch, TwoSides.TWO, unit));
         } else {
             TwoSides monitoredSide = getMonitoredSides().iterator().next();
             double power = getFlow(branch, monitoredSide, unit);
@@ -176,14 +172,18 @@ public class FlowCnecImpl extends AbstractBranchCnec<FlowCnec> implements FlowCn
     }
 
     private double getFlow(Branch branch, TwoSides side, Unit unit) {
-        double power = branch.getTerminal(side).getP();
+        double activeFlow = branch.getTerminal(side).getP();
+        double intensity = branch.getTerminal(side).getI();
         if (unit.equals(Unit.AMPERE)) {
-            power = branch.getTerminal(side).getI();
-            return Double.isNaN(power) ? branch.getTerminal(side).getP() * getFlowUnitMultiplierMegawattToAmpere(side) : power;
+            // In case flows are negative, we shall replace this value by its opposite
+            if (activeFlow < 0) {
+                intensity = -intensity;
+            }
+            return Double.isNaN(intensity) ? activeFlow * getFlowUnitMultiplierMegawattToAmpere(side) : intensity;
         } else if (!unit.equals(Unit.MEGAWATT)) {
             throw new OpenRaoException("FlowCnec can only be requested in AMPERE or MEGAWATT");
         }
-        return Double.isNaN(power) ? branch.getTerminal(side).getP() * getFlowUnitMultiplierMegawattToAmpere(side) : power;
+        return activeFlow;
     }
 
     @Override

--- a/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/FlowCnecImpl.java
+++ b/data/crac/crac-impl/src/main/java/com/powsybl/openrao/data/cracimpl/FlowCnecImpl.java
@@ -176,10 +176,7 @@ public class FlowCnecImpl extends AbstractBranchCnec<FlowCnec> implements FlowCn
         double intensity = branch.getTerminal(side).getI();
         if (unit.equals(Unit.AMPERE)) {
             // In case flows are negative, we shall replace this value by its opposite
-            if (activeFlow < 0) {
-                intensity = -intensity;
-            }
-            return Double.isNaN(intensity) ? activeFlow * getFlowUnitMultiplierMegawattToAmpere(side) : intensity;
+            return Double.isNaN(intensity) ? activeFlow * getFlowUnitMultiplierMegawattToAmpere(side) : Math.signum(activeFlow) * intensity;
         } else if (!unit.equals(Unit.MEGAWATT)) {
             throw new OpenRaoException("FlowCnec can only be requested in AMPERE or MEGAWATT");
         }

--- a/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/FlowCnecImplTest.java
+++ b/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/cracimpl/FlowCnecImplTest.java
@@ -98,6 +98,31 @@ class FlowCnecImplTest {
     }
 
     @Test
+    void testComputeValueAmpere() {
+        Network network = Mockito.mock(Network.class);
+        Branch branch3 = Mockito.mock(Branch.class);
+        Terminal terminal31 = Mockito.mock(Terminal.class);
+        Terminal terminal32 = Mockito.mock(Terminal.class);
+
+        Mockito.when(network.getBranch("AAE2AA1  AAE3AA1  1")).thenReturn(branch3);
+        Mockito.when(terminal31.getP()).thenReturn(-66.);
+        Mockito.when(terminal31.getI()).thenReturn(55.);
+        Mockito.when(terminal32.getP()).thenReturn(22.);
+        Mockito.when(terminal32.getI()).thenReturn(Double.NaN);
+        Mockito.when(branch3.getTerminal(ONE)).thenReturn(terminal31);
+        Mockito.when(branch3.getTerminal(TWO)).thenReturn(terminal32);
+
+        FlowCnec cnecA = crac.newFlowCnec().withId("cnec-A-id").withNetworkElement("AAE2AA1  AAE3AA1  1").withInstant(PREVENTIVE_INSTANT_ID)
+            .withNominalVoltage(222.)
+            .newThreshold().withUnit(AMPERE).withMin(5.).withMax(10.).withSide(TwoSides.ONE).add()
+            .newThreshold().withUnit(AMPERE).withMin(20.).withMax(300.).withSide(TwoSides.TWO).add()
+            .add();
+
+        assertEquals(-55., ((FlowCnecValue) cnecA.computeValue(network, AMPERE)).side1Value());
+        assertEquals(57.2, ((FlowCnecValue) cnecA.computeValue(network, AMPERE)).side2Value(), 0.1);
+    }
+
+    @Test
     void testComputeWorstMargin() {
         Network network = Mockito.mock(Network.class, Mockito.RETURNS_DEEP_STUBS);
         Branch branch1 = Mockito.mock(Branch.class, Mockito.RETURNS_DEEP_STUBS);

--- a/monitoring/src/main/java/com/powsybl/openrao/monitoring/Monitoring.java
+++ b/monitoring/src/main/java/com/powsybl/openrao/monitoring/Monitoring.java
@@ -233,7 +233,7 @@ public class Monitoring {
         if (state.getInstant().isCurative()) {
             Optional<Contingency> contingency = state.getContingency();
             crac.getStates(contingency.orElseThrow()).forEach(contingencyState ->
-                applyOptimalRemedialActions(state, network, raoResult));
+                applyOptimalRemedialActions(contingencyState, network, raoResult));
         } else {
             applyOptimalRemedialActions(state, network, raoResult);
         }


### PR DESCRIPTION
Bug fix:
* getFlow now matches the RAO's norms (cf postTreatIntensities) in Ampere with negative active powers.
* Monitoring modules weren't applying post-contingency remedial actions other than curative remedial actions.