### PR TITLE
Fix zero flows in result due to instant handling in SystematicSensitivityResult 

### DIFF
--- a/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
@@ -340,12 +340,13 @@ public class SystematicSensitivityResult {
     private StateResult getCnecStateResult(Cnec<?> cnec, Instant instant) {
         Optional<Contingency> optionalContingency = cnec.getState().getContingency();
         if (optionalContingency.isPresent()) {
+            String contingencyId = optionalContingency.get().getId();
             int maxAdmissibleInstantOrder = instant == null ? 1 : Math.max(1, instant.getOrder()); // when dealing with post-contingency CNECs, a null instant refers to the outage instant
             List<Integer> possibleInstants = postContingencyResults.keySet().stream()
                 .filter(instantOrder -> instantOrder <= cnec.getState().getInstant().getOrder() && instantOrder <= maxAdmissibleInstantOrder)
                 .sorted(Comparator.reverseOrder())
+                .filter(instantOrder -> postContingencyResults.get(instantOrder).containsKey(contingencyId))
                 .toList();
-            String contingencyId = optionalContingency.get().getId();
             return possibleInstants.isEmpty() ? null : postContingencyResults.get(possibleInstants.get(0)).get(contingencyId);
         } else {
             return nStateResult; // when dealing with preventive CNECs, a null instant refers to the initial instant

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResultTest.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResultTest.java
@@ -11,6 +11,7 @@ import com.powsybl.openrao.commons.Unit;
 import com.powsybl.iidm.network.TwoSides;
 import com.powsybl.openrao.data.cracapi.CracFactory;
 import com.powsybl.openrao.data.cracapi.State;
+import com.powsybl.openrao.data.cracapi.cnec.FlowCnecAdder;
 import com.powsybl.openrao.data.cracapi.rangeaction.HvdcRangeAction;
 import com.powsybl.glsk.commons.ZonalData;
 import com.powsybl.openrao.data.cracapi.Crac;
@@ -291,6 +292,84 @@ class SystematicSensitivityResultTest {
         assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.PARTIAL_FAILURE, result.getStatus());
         assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.SUCCESS, result.getStatus(crac.getPreventiveState()));
         assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE, result.getStatus(contingencyState));
+    }
+
+    //This test simulates what happens after a second preventive, where some curative results are stored in outage results.
+    //We do this to avoid recomputing multiple times the same contingency while no remedial action was applied in later instants.
+    @Test
+    void testCurativeResultAtOutageInstant() {
+        setUpWith12Nodes();
+
+        FlowCnecAdder cnecAdder = crac.newFlowCnec()
+            .withId("cnec2stateOutageContingency2")
+            .withNetworkElement("FFR2AA1  DDE3AA1  1")
+            .withInstant(OUTAGE_INSTANT_ID)
+            .withContingency("Contingency FR1 FR2")
+            .withOptimized(true)
+            .withOperator("operator2")
+            .withReliabilityMargin(95.)
+            .withNominalVoltage(380.)
+            .withIMax(5000.);
+        Set.of(TwoSides.ONE, TwoSides.TWO).forEach(side ->
+            cnecAdder.newThreshold()
+                .withUnit(Unit.MEGAWATT)
+                .withSide(TwoSides.ONE)
+                .withMin(-1800.)
+                .withMax(1800.)
+                .add());
+        cnecAdder.add();
+
+        outageInstantOrder = crac.getInstant(OUTAGE_INSTANT_ID).getOrder();
+        int curativeInstantOrder = crac.getInstant(CURATIVE_INSTANT_ID).getOrder();
+
+        //run sensi on outage instant for outageCnec
+        FlowCnec outageCnec = crac.getFlowCnec("cnec2stateOutageContingency2");
+        Contingency outageContingency = outageCnec.getState().getContingency().orElseThrow();
+        SensitivityFactor outageSensitivityFactor = new SensitivityFactor(
+            SensitivityFunctionType.BRANCH_ACTIVE_POWER_1,
+            outageCnec.getNetworkElement().getId(),
+            SensitivityVariableType.TRANSFORMER_PHASE,
+            "BBE2AA1  BBE3AA1  1",
+            false,
+            new ContingencyContext(outageContingency.getId(), ContingencyContextType.SPECIFIC)
+        );
+        SensitivityAnalysisResult sensitivityAnalysisResult = SensitivityAnalysis.find().run(network,
+            List.of(outageSensitivityFactor),
+            List.of(outageContingency),
+            new ArrayList<>(),
+            SensitivityAnalysisParameters.load());
+        SystematicSensitivityResult result = new SystematicSensitivityResult().completeData(sensitivityAnalysisResult, outageInstantOrder);
+
+        //run sensi on curative instant for curativeCnec
+        FlowCnec curativeCnec = crac.getFlowCnec("cnec1stateCurativeContingency1");
+        Contingency curativeContingency = curativeCnec.getState().getContingency().orElseThrow();
+        SensitivityFactor curativeSensitivityFactor = new SensitivityFactor(
+            SensitivityFunctionType.BRANCH_ACTIVE_POWER_1,
+            curativeCnec.getNetworkElement().getId(),
+            SensitivityVariableType.TRANSFORMER_PHASE,
+            "BBE2AA1  BBE3AA1  1",
+            false,
+            new ContingencyContext(curativeContingency.getId(), ContingencyContextType.SPECIFIC)
+        );
+        sensitivityAnalysisResult = SensitivityAnalysis.find().run(network,
+            List.of(curativeSensitivityFactor),
+            List.of(curativeContingency),
+            new ArrayList<>(),
+            SensitivityAnalysisParameters.load());
+        result.completeData(sensitivityAnalysisResult, curativeInstantOrder);
+
+        //correct flows are available for both factors for all instants
+        //0 represents a missing value (this is due to the way load flow engines represent an open line, we need 0 as a default value)
+        assertEquals(-20, result.getReferenceFlow(outageCnec, TwoSides.ONE));
+        assertEquals(-20, result.getReferenceFlow(outageCnec, TwoSides.ONE, crac.getInstant(OUTAGE_INSTANT_ID)));
+        assertEquals(-20, result.getReferenceFlow(outageCnec, TwoSides.ONE, crac.getInstant(AUTO_INSTANT_ID)));
+        assertEquals(-20, result.getReferenceFlow(outageCnec, TwoSides.ONE, crac.getInstant(CURATIVE_INSTANT_ID)));
+
+        assertEquals(-20, result.getReferenceFlow(curativeCnec, TwoSides.ONE));
+        assertEquals(0, result.getReferenceFlow(curativeCnec, TwoSides.ONE, crac.getInstant(OUTAGE_INSTANT_ID)));
+        assertEquals(0, result.getReferenceFlow(curativeCnec, TwoSides.ONE, crac.getInstant(AUTO_INSTANT_ID)));
+        assertEquals(-20, result.getReferenceFlow(curativeCnec, TwoSides.ONE, crac.getInstant(CURATIVE_INSTANT_ID)));
+
     }
 
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The SystematicSensitivityResult will return 0 if you ask it for the flow on a line at the curative instant if the computation was only done for the outage instant or auto instant. However, this is the nominal case for curative cnecs after a second preventive, since to avoid duplicating the sensitivity computations, we only run them at the outage instant for contingencies where no auto/curative actions were applied.
This resulted in flows equal to 0 in the RaoResult and exported in the json.


**What is the new behavior (if this is a feature change)?**
Now checks all instant prior to find the latest result available.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Issue detected during SWE capacity calculation.
