### PR TITLE
Fix bug 2 p

### DIFF
--- a/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapter.java
+++ b/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapter.java
@@ -40,11 +40,11 @@ final class SystematicSensitivityAdapter {
         SensitivityAnalysisResult result;
         try {
             result = SensitivityAnalysis.find(sensitivityProvider).run(network,
-                    network.getVariantManager().getWorkingVariantId(),
-                    cnecSensitivityProvider.getAllFactors(network),
-                    cnecSensitivityProvider.getContingencies(network),
-                    cnecSensitivityProvider.getVariableSets(),
-                    sensitivityComputationParameters);
+                network.getVariantManager().getWorkingVariantId(),
+                cnecSensitivityProvider.getAllFactors(network),
+                cnecSensitivityProvider.getContingencies(network),
+                cnecSensitivityProvider.getVariableSets(),
+                sensitivityComputationParameters);
         } catch (Exception e) {
             TECHNICAL_LOGS.error(String.format("Systematic sensitivity analysis failed: %s", e.getMessage()));
             return new SystematicSensitivityResult(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE);
@@ -76,21 +76,21 @@ final class SystematicSensitivityAdapter {
         TECHNICAL_LOGS.debug("... (1/{}) {} state(s) without RA ", statesWithRa.size() + 1, statesWithoutRa.size());
 
         List<Contingency> contingenciesWithoutRa = statesWithoutRa.stream()
-                .filter(state -> state.getContingency().isPresent())
-                .map(state -> state.getContingency().get())
-                .distinct()
-                .toList();
+            .filter(state -> state.getContingency().isPresent())
+            .map(state -> state.getContingency().get())
+            .distinct()
+            .toList();
 
         SystematicSensitivityResult result = new SystematicSensitivityResult();
         List<SensitivityFactor> allFactorsWithoutRa = cnecSensitivityProvider.getBasecaseFactors(network);
         allFactorsWithoutRa.addAll(cnecSensitivityProvider.getContingencyFactors(network, contingenciesWithoutRa));
         try {
             result.completeData(SensitivityAnalysis.find(sensitivityProvider).run(network,
-                    network.getVariantManager().getWorkingVariantId(),
-                    allFactorsWithoutRa,
-                    contingenciesWithoutRa,
-                    cnecSensitivityProvider.getVariableSets(),
-                    sensitivityComputationParameters), outageInstant.getOrder());
+                network.getVariantManager().getWorkingVariantId(),
+                allFactorsWithoutRa,
+                contingenciesWithoutRa,
+                cnecSensitivityProvider.getVariableSets(),
+                sensitivityComputationParameters), outageInstant.getOrder());
         } catch (Exception e) {
             TECHNICAL_LOGS.error(String.format("Systematic sensitivity analysis failed: %s", e.getMessage()));
             return new SystematicSensitivityResult(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE);
@@ -124,11 +124,11 @@ final class SystematicSensitivityAdapter {
 
             try {
                 result.completeData(SensitivityAnalysis.find(sensitivityProvider).run(network,
-                        network.getVariantManager().getWorkingVariantId(),
-                        cnecSensitivityProvider.getContingencyFactors(network, contingencyList),
-                        contingencyList,
-                        cnecSensitivityProvider.getVariableSets(),
-                        sensitivityComputationParameters), state.getInstant().getOrder());
+                    network.getVariantManager().getWorkingVariantId(),
+                    cnecSensitivityProvider.getContingencyFactors(network, contingencyList),
+                    contingencyList,
+                    cnecSensitivityProvider.getVariableSets(),
+                    sensitivityComputationParameters), state.getInstant().getOrder());
             } catch (Exception e) {
                 TECHNICAL_LOGS.error(String.format("Systematic sensitivity analysis failed for state %s : %s", state.getId(), e.getMessage()));
                 result.completeDataWithFailingPerimeter(state.getInstant().getOrder(), optContingency.get().getId());

--- a/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
@@ -94,7 +94,7 @@ public class SystematicSensitivityResult {
             StateResult contingencyStateResult = new StateResult();
             contingencyStateResult.status = contingencyStatus.getStatus().equals(SensitivityAnalysisResult.Status.FAILURE) ? SensitivityComputationStatus.FAILURE : SensitivityComputationStatus.SUCCESS;
             results.getValues(contingencyStatus.getContingencyId()).forEach(sensitivityValue ->
-                    fillIndividualValue(sensitivityValue, contingencyStateResult, results.getFactors(), contingencyStatus.getStatus())
+                fillIndividualValue(sensitivityValue, contingencyStateResult, results.getFactors(), contingencyStatus.getStatus())
             );
             postContingencyResults.get(instantOrder).put(contingencyStatus.getContingencyId(), contingencyStateResult);
         }
@@ -127,29 +127,29 @@ public class SystematicSensitivityResult {
      */
     private void postTreatIntensitiesOnState(StateResult stateResult) {
         stateResult.getReferenceFlows()
-                .forEach((neId, sideAndFlow) -> {
-                    if (stateResult.getReferenceIntensities().containsKey(neId)) {
-                        sideAndFlow.forEach((side, flow) -> {
-                            if (flow < 0) {
-                                stateResult.getReferenceIntensities().get(neId).put(side, -stateResult.getReferenceIntensities().get(neId).get(side));
-                            }
-                        });
-                    }
-                    if (stateResult.getIntensitySensitivities().containsKey(neId)) {
-                        sideAndFlow.forEach((side, flow) -> {
-                            if (flow < 0) {
-                                Map<String, Map<TwoSides, Double>> sensitivities = stateResult.getIntensitySensitivities().get(neId);
-                                sensitivities.forEach((actionId, sideToSensi) -> sensitivities.get(actionId).put(side, -sideToSensi.get(side)));
-                            }
-                        });
-                    }
-                });
+            .forEach((neId, sideAndFlow) -> {
+                if (stateResult.getReferenceIntensities().containsKey(neId)) {
+                    sideAndFlow.forEach((side, flow) -> {
+                        if (flow < 0) {
+                            stateResult.getReferenceIntensities().get(neId).put(side, -stateResult.getReferenceIntensities().get(neId).get(side));
+                        }
+                    });
+                }
+                if (stateResult.getIntensitySensitivities().containsKey(neId)) {
+                    sideAndFlow.forEach((side, flow) -> {
+                        if (flow < 0) {
+                            Map<String, Map<TwoSides, Double>> sensitivities = stateResult.getIntensitySensitivities().get(neId);
+                            sensitivities.forEach((actionId, sideToSensi) -> sensitivities.get(actionId).put(side, -sideToSensi.get(side)));
+                        }
+                    });
+                }
+            });
     }
 
     public SystematicSensitivityResult postTreatHvdcs(Network network, Map<String, HvdcRangeAction> hvdcRangeActions) {
         postTreatHvdcsOnState(network, hvdcRangeActions, nStateResult);
         postContingencyResults.values().forEach(stringStateResultMap ->
-                stringStateResultMap.values().forEach(stateResult -> postTreatHvdcsOnState(network, hvdcRangeActions, stateResult))
+            stringStateResultMap.values().forEach(stateResult -> postTreatHvdcsOnState(network, hvdcRangeActions, stateResult))
         );
         return this;
     }
@@ -203,16 +203,16 @@ public class SystematicSensitivityResult {
 
         if (factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_ACTIVE_POWER_1) || factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_ACTIVE_POWER_2)) {
             stateResult.getReferenceFlows()
-                    .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
-                    .putIfAbsent(side, reference * activePowerCoefficient);
+                .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
+                .putIfAbsent(side, reference * activePowerCoefficient);
             stateResult.getFlowSensitivities()
-                    .computeIfAbsent(factor.getFunctionId(), k -> new HashMap<>())
-                    .computeIfAbsent(factor.getVariableId(), k -> new EnumMap<>(TwoSides.class))
-                    .putIfAbsent(side, sensitivity * activePowerCoefficient);
+                .computeIfAbsent(factor.getFunctionId(), k -> new HashMap<>())
+                .computeIfAbsent(factor.getVariableId(), k -> new EnumMap<>(TwoSides.class))
+                .putIfAbsent(side, sensitivity * activePowerCoefficient);
         } else if (factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_CURRENT_1) || factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_CURRENT_2)) {
             stateResult.getReferenceIntensities()
-                    .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
-                    .putIfAbsent(side, reference);
+                .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
+                .putIfAbsent(side, reference);
         }
     }
 
@@ -231,9 +231,9 @@ public class SystematicSensitivityResult {
         Optional<Contingency> optionalContingency = state.getContingency();
         if (optionalContingency.isPresent()) {
             List<Integer> possibleInstants = postContingencyResults.keySet().stream()
-                    .filter(instantOrder -> instantOrder <= state.getInstant().getOrder())
-                    .sorted(Comparator.reverseOrder())
-                    .toList();
+                .filter(instantOrder -> instantOrder <= state.getInstant().getOrder())
+                .sorted(Comparator.reverseOrder())
+                .toList();
             for (Integer instantOrder : possibleInstants) {
                 // Use latest sensi computed on state
                 if (postContingencyResults.get(instantOrder).containsKey(optionalContingency.get().getId())) {
@@ -257,8 +257,8 @@ public class SystematicSensitivityResult {
     public double getReferenceFlow(FlowCnec cnec, TwoSides side) {
         StateResult stateResult = getCnecStateResult(cnec);
         if (stateResult == null ||
-                !stateResult.getReferenceFlows().containsKey(cnec.getNetworkElement().getId()) ||
-                !stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).containsKey(side)) {
+            !stateResult.getReferenceFlows().containsKey(cnec.getNetworkElement().getId()) ||
+            !stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).get(side);
@@ -267,8 +267,8 @@ public class SystematicSensitivityResult {
     public double getReferenceFlow(FlowCnec cnec, TwoSides side, Instant instant) {
         StateResult stateResult = getCnecStateResult(cnec, instant);
         if (stateResult == null ||
-                !stateResult.getReferenceFlows().containsKey(cnec.getNetworkElement().getId()) ||
-                !stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).containsKey(side)) {
+            !stateResult.getReferenceFlows().containsKey(cnec.getNetworkElement().getId()) ||
+            !stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).get(side);
@@ -277,8 +277,8 @@ public class SystematicSensitivityResult {
     public double getReferenceIntensity(FlowCnec cnec, TwoSides side) {
         StateResult stateResult = getCnecStateResult(cnec);
         if (stateResult == null ||
-                !stateResult.getReferenceIntensities().containsKey(cnec.getNetworkElement().getId()) ||
-                !stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).containsKey(side)) {
+            !stateResult.getReferenceIntensities().containsKey(cnec.getNetworkElement().getId()) ||
+            !stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).get(side);
@@ -287,8 +287,8 @@ public class SystematicSensitivityResult {
     public double getReferenceIntensity(FlowCnec cnec, TwoSides side, Instant instant) {
         StateResult stateResult = getCnecStateResult(cnec, instant);
         if (stateResult == null ||
-                !stateResult.getReferenceIntensities().containsKey(cnec.getNetworkElement().getId()) ||
-                !stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).containsKey(side)) {
+            !stateResult.getReferenceIntensities().containsKey(cnec.getNetworkElement().getId()) ||
+            !stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).get(side);
@@ -305,9 +305,9 @@ public class SystematicSensitivityResult {
     public double getSensitivityOnFlow(String variableId, FlowCnec cnec, TwoSides side) {
         StateResult stateResult = getCnecStateResult(cnec);
         if (stateResult == null ||
-                !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId()) ||
-                !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).containsKey(variableId) ||
-                !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).containsKey(side)) {
+            !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId()) ||
+            !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).containsKey(variableId) ||
+            !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).get(side);
@@ -316,9 +316,9 @@ public class SystematicSensitivityResult {
     public double getSensitivityOnFlow(String variableId, FlowCnec cnec, TwoSides side, Instant instant) {
         StateResult stateResult = getCnecStateResult(cnec, instant);
         if (stateResult == null ||
-                !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId()) ||
-                !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).containsKey(variableId) ||
-                !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).containsKey(side)) {
+            !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId()) ||
+            !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).containsKey(variableId) ||
+            !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).get(side);
@@ -331,9 +331,9 @@ public class SystematicSensitivityResult {
         Optional<Contingency> optionalContingency = cnec.getState().getContingency();
         if (optionalContingency.isPresent()) {
             List<Integer> possibleInstants = postContingencyResults.keySet().stream()
-                    .filter(instantOrder -> instantOrder <= cnec.getState().getInstant().getOrder())
-                    .sorted(Comparator.reverseOrder())
-                    .toList();
+                .filter(instantOrder -> instantOrder <= cnec.getState().getInstant().getOrder())
+                .sorted(Comparator.reverseOrder())
+                .toList();
             for (Integer instantOrder : possibleInstants) {
                 // Use latest sensi computed on the cnec's contingency amidst the last instants before cnec state.
                 String contingencyId = optionalContingency.get().getId();
@@ -354,10 +354,10 @@ public class SystematicSensitivityResult {
             String contingencyId = optionalContingency.get().getId();
             int maxAdmissibleInstantOrder = instant == null ? 1 : Math.max(1, instant.getOrder()); // when dealing with post-contingency CNECs, a null instant refers to the outage instant
             List<Integer> possibleInstants = postContingencyResults.keySet().stream()
-                    .filter(instantOrder -> instantOrder <= cnec.getState().getInstant().getOrder() && instantOrder <= maxAdmissibleInstantOrder)
-                    .sorted(Comparator.reverseOrder())
-                    .filter(instantOrder -> postContingencyResults.get(instantOrder).containsKey(contingencyId))
-                    .toList();
+                .filter(instantOrder -> instantOrder <= cnec.getState().getInstant().getOrder() && instantOrder <= maxAdmissibleInstantOrder)
+                .sorted(Comparator.reverseOrder())
+                .filter(instantOrder -> postContingencyResults.get(instantOrder).containsKey(contingencyId))
+                .toList();
             return possibleInstants.isEmpty() ? null : postContingencyResults.get(possibleInstants.get(0)).get(contingencyId);
         } else {
             return nStateResult; // when dealing with preventive CNECs, a null instant refers to the initial instant

--- a/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
@@ -111,6 +111,7 @@ public class SystematicSensitivityResult {
         this.status = SensitivityComputationStatus.PARTIAL_FAILURE;
         StateResult contingencyStateResult = new StateResult();
         contingencyStateResult.status = SensitivityComputationStatus.FAILURE;
+        postContingencyResults.putIfAbsent(instantOrder, new HashMap<>());
         postContingencyResults.get(instantOrder).put(contingencyId, contingencyStateResult);
         return this;
     }

--- a/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
@@ -94,7 +94,7 @@ public class SystematicSensitivityResult {
             StateResult contingencyStateResult = new StateResult();
             contingencyStateResult.status = contingencyStatus.getStatus().equals(SensitivityAnalysisResult.Status.FAILURE) ? SensitivityComputationStatus.FAILURE : SensitivityComputationStatus.SUCCESS;
             results.getValues(contingencyStatus.getContingencyId()).forEach(sensitivityValue ->
-                fillIndividualValue(sensitivityValue, contingencyStateResult, results.getFactors(), contingencyStatus.getStatus())
+                    fillIndividualValue(sensitivityValue, contingencyStateResult, results.getFactors(), contingencyStatus.getStatus())
             );
             postContingencyResults.get(instantOrder).put(contingencyStatus.getContingencyId(), contingencyStateResult);
         }
@@ -104,6 +104,14 @@ public class SystematicSensitivityResult {
         if (nStateResult.status != SensitivityComputationStatus.FAILURE && anyContingencyFailure) {
             this.status = SensitivityComputationStatus.PARTIAL_FAILURE;
         }
+        return this;
+    }
+
+    public SystematicSensitivityResult completeDataWithFailingPerimeter(int instantOrder, String contingencyId) {
+        this.status = SensitivityComputationStatus.PARTIAL_FAILURE;
+        StateResult contingencyStateResult = new StateResult();
+        contingencyStateResult.status = SensitivityComputationStatus.FAILURE;
+        postContingencyResults.get(instantOrder).put(contingencyId, contingencyStateResult);
         return this;
     }
 
@@ -119,29 +127,29 @@ public class SystematicSensitivityResult {
      */
     private void postTreatIntensitiesOnState(StateResult stateResult) {
         stateResult.getReferenceFlows()
-            .forEach((neId, sideAndFlow) -> {
-                if (stateResult.getReferenceIntensities().containsKey(neId)) {
-                    sideAndFlow.forEach((side, flow) -> {
-                        if (flow < 0) {
-                            stateResult.getReferenceIntensities().get(neId).put(side, -stateResult.getReferenceIntensities().get(neId).get(side));
-                        }
-                    });
-                }
-                if (stateResult.getIntensitySensitivities().containsKey(neId)) {
-                    sideAndFlow.forEach((side, flow) -> {
-                        if (flow < 0) {
-                            Map<String, Map<TwoSides, Double>> sensitivities = stateResult.getIntensitySensitivities().get(neId);
-                            sensitivities.forEach((actionId, sideToSensi) -> sensitivities.get(actionId).put(side, -sideToSensi.get(side)));
-                        }
-                    });
-                }
-            });
+                .forEach((neId, sideAndFlow) -> {
+                    if (stateResult.getReferenceIntensities().containsKey(neId)) {
+                        sideAndFlow.forEach((side, flow) -> {
+                            if (flow < 0) {
+                                stateResult.getReferenceIntensities().get(neId).put(side, -stateResult.getReferenceIntensities().get(neId).get(side));
+                            }
+                        });
+                    }
+                    if (stateResult.getIntensitySensitivities().containsKey(neId)) {
+                        sideAndFlow.forEach((side, flow) -> {
+                            if (flow < 0) {
+                                Map<String, Map<TwoSides, Double>> sensitivities = stateResult.getIntensitySensitivities().get(neId);
+                                sensitivities.forEach((actionId, sideToSensi) -> sensitivities.get(actionId).put(side, -sideToSensi.get(side)));
+                            }
+                        });
+                    }
+                });
     }
 
     public SystematicSensitivityResult postTreatHvdcs(Network network, Map<String, HvdcRangeAction> hvdcRangeActions) {
         postTreatHvdcsOnState(network, hvdcRangeActions, nStateResult);
         postContingencyResults.values().forEach(stringStateResultMap ->
-            stringStateResultMap.values().forEach(stateResult -> postTreatHvdcsOnState(network, hvdcRangeActions, stateResult))
+                stringStateResultMap.values().forEach(stateResult -> postTreatHvdcsOnState(network, hvdcRangeActions, stateResult))
         );
         return this;
     }
@@ -195,16 +203,16 @@ public class SystematicSensitivityResult {
 
         if (factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_ACTIVE_POWER_1) || factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_ACTIVE_POWER_2)) {
             stateResult.getReferenceFlows()
-                .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
-                .putIfAbsent(side, reference * activePowerCoefficient);
+                    .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
+                    .putIfAbsent(side, reference * activePowerCoefficient);
             stateResult.getFlowSensitivities()
-                .computeIfAbsent(factor.getFunctionId(), k -> new HashMap<>())
-                .computeIfAbsent(factor.getVariableId(), k -> new EnumMap<>(TwoSides.class))
-                .putIfAbsent(side, sensitivity * activePowerCoefficient);
+                    .computeIfAbsent(factor.getFunctionId(), k -> new HashMap<>())
+                    .computeIfAbsent(factor.getVariableId(), k -> new EnumMap<>(TwoSides.class))
+                    .putIfAbsent(side, sensitivity * activePowerCoefficient);
         } else if (factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_CURRENT_1) || factor.getFunctionType().equals(SensitivityFunctionType.BRANCH_CURRENT_2)) {
             stateResult.getReferenceIntensities()
-                .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
-                .putIfAbsent(side, reference);
+                    .computeIfAbsent(factor.getFunctionId(), k -> new EnumMap<>(TwoSides.class))
+                    .putIfAbsent(side, reference);
         }
     }
 
@@ -259,8 +267,8 @@ public class SystematicSensitivityResult {
     public double getReferenceFlow(FlowCnec cnec, TwoSides side, Instant instant) {
         StateResult stateResult = getCnecStateResult(cnec, instant);
         if (stateResult == null ||
-            !stateResult.getReferenceFlows().containsKey(cnec.getNetworkElement().getId()) ||
-            !stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).containsKey(side)) {
+                !stateResult.getReferenceFlows().containsKey(cnec.getNetworkElement().getId()) ||
+                !stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getReferenceFlows().get(cnec.getNetworkElement().getId()).get(side);
@@ -279,8 +287,8 @@ public class SystematicSensitivityResult {
     public double getReferenceIntensity(FlowCnec cnec, TwoSides side, Instant instant) {
         StateResult stateResult = getCnecStateResult(cnec, instant);
         if (stateResult == null ||
-            !stateResult.getReferenceIntensities().containsKey(cnec.getNetworkElement().getId()) ||
-            !stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).containsKey(side)) {
+                !stateResult.getReferenceIntensities().containsKey(cnec.getNetworkElement().getId()) ||
+                !stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getReferenceIntensities().get(cnec.getNetworkElement().getId()).get(side);
@@ -308,9 +316,9 @@ public class SystematicSensitivityResult {
     public double getSensitivityOnFlow(String variableId, FlowCnec cnec, TwoSides side, Instant instant) {
         StateResult stateResult = getCnecStateResult(cnec, instant);
         if (stateResult == null ||
-            !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId()) ||
-            !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).containsKey(variableId) ||
-            !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).containsKey(side)) {
+                !stateResult.getFlowSensitivities().containsKey(cnec.getNetworkElement().getId()) ||
+                !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).containsKey(variableId) ||
+                !stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).containsKey(side)) {
             return 0.0;
         }
         return stateResult.getFlowSensitivities().get(cnec.getNetworkElement().getId()).get(variableId).get(side);
@@ -346,10 +354,10 @@ public class SystematicSensitivityResult {
             String contingencyId = optionalContingency.get().getId();
             int maxAdmissibleInstantOrder = instant == null ? 1 : Math.max(1, instant.getOrder()); // when dealing with post-contingency CNECs, a null instant refers to the outage instant
             List<Integer> possibleInstants = postContingencyResults.keySet().stream()
-                .filter(instantOrder -> instantOrder <= cnec.getState().getInstant().getOrder() && instantOrder <= maxAdmissibleInstantOrder)
-                .sorted(Comparator.reverseOrder())
-                .filter(instantOrder -> postContingencyResults.get(instantOrder).containsKey(contingencyId))
-                .toList();
+                    .filter(instantOrder -> instantOrder <= cnec.getState().getInstant().getOrder() && instantOrder <= maxAdmissibleInstantOrder)
+                    .sorted(Comparator.reverseOrder())
+                    .filter(instantOrder -> postContingencyResults.get(instantOrder).containsKey(contingencyId))
+                    .toList();
             return possibleInstants.isEmpty() ? null : postContingencyResults.get(possibleInstants.get(0)).get(contingencyId);
         } else {
             return nStateResult; // when dealing with preventive CNECs, a null instant refers to the initial instant

--- a/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
+++ b/sensitivity-analysis/src/main/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResult.java
@@ -78,13 +78,13 @@ public class SystematicSensitivityResult {
 
     public SystematicSensitivityResult completeData(SensitivityAnalysisResult results, Integer instantOrder) {
         postContingencyResults.putIfAbsent(instantOrder, new HashMap<>());
+        // if a failing perimeter was already run, then the status would be set to PARTIAL_FAILURE
+        boolean anyContingencyFailure = this.status == SensitivityComputationStatus.PARTIAL_FAILURE;
         // status set to failure initially, and set to success if we find at least one non NaN value
         this.status = SensitivityComputationStatus.FAILURE;
         if (results == null) {
             return this;
         }
-
-        boolean anyContingencyFailure = false;
 
         results.getPreContingencyValues().forEach(sensitivityValue -> fillIndividualValue(sensitivityValue, nStateResult, results.getFactors(), SensitivityAnalysisResult.Status.SUCCESS));
         for (SensitivityAnalysisResult.SensitivityContingencyStatus contingencyStatus : results.getContingencyStatuses()) {

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/MockSensiProvider.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/MockSensiProvider.java
@@ -13,6 +13,7 @@ import com.powsybl.contingency.Contingency;
 import com.powsybl.contingency.ContingencyContextType;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.iidm.network.TwoWindingsTransformer;
+import com.powsybl.openrao.commons.OpenRaoException;
 import com.powsybl.sensitivity.*;
 
 import java.util.List;
@@ -28,6 +29,9 @@ public final class MockSensiProvider implements SensitivityAnalysisProvider {
     @Override
     public CompletableFuture<Void> run(Network network, String s, SensitivityFactorReader sensitivityFactorReader, SensitivityResultWriter sensitivityResultWriter, List<Contingency> contingencies, List<SensitivityVariableSet> glsks, SensitivityAnalysisParameters sensitivityAnalysisParameters, ComputationManager computationManager, ReportNode reportNode) {
         return CompletableFuture.runAsync(() -> {
+            if (network.getNameOrId().equals("Mock_Exception")) {
+                throw new OpenRaoException("Mocked exception");
+            }
             TwoWindingsTransformer pst = network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1");
             if (pst == null || pst.getPhaseTapChanger().getTapPosition() == 0) {
                 // used for most of the tests

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/MockSensiProvider.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/MockSensiProvider.java
@@ -25,12 +25,19 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 @AutoService(SensitivityAnalysisProvider.class)
 public final class MockSensiProvider implements SensitivityAnalysisProvider {
+    int counter = 0;
 
     @Override
     public CompletableFuture<Void> run(Network network, String s, SensitivityFactorReader sensitivityFactorReader, SensitivityResultWriter sensitivityResultWriter, List<Contingency> contingencies, List<SensitivityVariableSet> glsks, SensitivityAnalysisParameters sensitivityAnalysisParameters, ComputationManager computationManager, ReportNode reportNode) {
         return CompletableFuture.runAsync(() -> {
             if (network.getNameOrId().equals("Mock_Exception")) {
                 throw new OpenRaoException("Mocked exception");
+            }
+            if (network.getNameOrId().equals("Second_Run_Exception")) {
+                counter++;
+                if (counter == 2) {
+                    throw new OpenRaoException("Mocked exception on second round");
+                }
             }
             TwoWindingsTransformer pst = network.getTwoWindingsTransformer("BBE2AA1  BBE3AA1  1");
             if (pst == null || pst.getPhaseTapChanger().getTapPosition() == 0) {

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
@@ -165,10 +165,40 @@ class SystematicSensitivityAdapterTest {
 
     @Test
     void testCatchInRunSensitivity() {
+        Network network = NetworkImportsUtil.import12NodesNetwork();
+        network.setName("Mock_Exception");
         Crac crac = CommonCracCreation.createWithPreventivePstRange(Set.of(ONE, TWO));
         Instant outageInstant = crac.getInstant(OUTAGE_INSTANT_ID);
         RangeActionSensitivityProvider factorProvider = new RangeActionSensitivityProvider(crac.getRangeActions(), crac.getFlowCnecs(), Set.of(Unit.MEGAWATT, Unit.AMPERE));
-        SystematicSensitivityResult result = SystematicSensitivityAdapter.runSensitivity(null, factorProvider, new SensitivityAnalysisParameters(), "MockSensi", outageInstant);
+        SystematicSensitivityResult result = SystematicSensitivityAdapter.runSensitivity(network, factorProvider, new SensitivityAnalysisParameters(), "MockSensi", outageInstant);
+        assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE, result.getStatus());
+    }
+
+    @Test
+    void testCatchInRunSensitivityWithAppliedRa() {
+        Network network = NetworkImportsUtil.import12NodesNetwork();
+        network.setName("Mock_Exception");
+        Crac crac = CommonCracCreation.createWithPreventivePstRange(Set.of(ONE, TWO));
+        Instant curativeInstant = crac.getInstant(CURATIVE_INSTANT_ID);
+        crac.newFlowCnec()
+            .withId("cnec2stateOutageContingency1")
+            .withNetworkElement("FFR2AA1  DDE3AA1  1")
+            .withInstant(OUTAGE_INSTANT_ID)
+            .withContingency("Contingency FR1 FR3")
+            .withOptimized(true)
+            .withOperator("operator2")
+            .newThreshold().withUnit(Unit.MEGAWATT).withSide(ONE).withMin(-1500.).withMax(1500.).add()
+            .newThreshold().withUnit(Unit.MEGAWATT).withSide(TWO).withMin(-1500.).withMax(1500.).add()
+            .newThreshold().withUnit(Unit.PERCENT_IMAX).withSide(ONE).withMin(-0.3).withMax(0.3).add()
+            .newThreshold().withUnit(Unit.PERCENT_IMAX).withSide(TWO).withMin(-0.3).withMax(0.3).add()
+            .withNominalVoltage(380.)
+            .withIMax(5000.)
+            .add();
+        RangeActionSensitivityProvider factorProvider = new RangeActionSensitivityProvider(crac.getRangeActions(), crac.getFlowCnecs(), Set.of(Unit.MEGAWATT, Unit.AMPERE));
+        AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
+        appliedRemedialActions.addAppliedRangeAction(crac.getState("Contingency FR1 FR3", curativeInstant), crac.getPstRangeAction("pst"), -3.1);
+
+        SystematicSensitivityResult result = SystematicSensitivityAdapter.runSensitivity(network, factorProvider, appliedRemedialActions, new SensitivityAnalysisParameters(), "MockSensi", crac.getOutageInstant());
         assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE, result.getStatus());
     }
 }

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
@@ -177,7 +177,7 @@ class SystematicSensitivityAdapterTest {
     @Test
     void testCatchInRunSensitivityWithAppliedRa() {
         Network network = NetworkImportsUtil.import12NodesNetwork();
-        network.setName("Mock_Exception");
+        network.setName("Second_Run_Exception");
         Crac crac = CommonCracCreation.createWithPreventivePstRange(Set.of(ONE, TWO));
         Instant curativeInstant = crac.getInstant(CURATIVE_INSTANT_ID);
         crac.newFlowCnec()
@@ -199,6 +199,6 @@ class SystematicSensitivityAdapterTest {
         appliedRemedialActions.addAppliedRangeAction(crac.getState("Contingency FR1 FR3", curativeInstant), crac.getPstRangeAction("pst"), -3.1);
 
         SystematicSensitivityResult result = SystematicSensitivityAdapter.runSensitivity(network, factorProvider, appliedRemedialActions, new SensitivityAnalysisParameters(), "MockSensi", crac.getOutageInstant());
-        assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE, result.getStatus());
+        assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.PARTIAL_FAILURE, result.getStatus());
     }
 }

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
@@ -175,7 +175,35 @@ class SystematicSensitivityAdapterTest {
     }
 
     @Test
-    void testCatchInRunSensitivityWithAppliedRa() {
+    void testFirstCatchInRunSensitivityWithAppliedRa() {
+        Network network = NetworkImportsUtil.import12NodesNetwork();
+        network.setName("Mock_Exception");
+        Crac crac = CommonCracCreation.createWithPreventivePstRange(Set.of(ONE, TWO));
+        Instant curativeInstant = crac.getInstant(CURATIVE_INSTANT_ID);
+        crac.newFlowCnec()
+            .withId("cnec2stateOutageContingency1")
+            .withNetworkElement("FFR2AA1  DDE3AA1  1")
+            .withInstant(OUTAGE_INSTANT_ID)
+            .withContingency("Contingency FR1 FR3")
+            .withOptimized(true)
+            .withOperator("operator2")
+            .newThreshold().withUnit(Unit.MEGAWATT).withSide(ONE).withMin(-1500.).withMax(1500.).add()
+            .newThreshold().withUnit(Unit.MEGAWATT).withSide(TWO).withMin(-1500.).withMax(1500.).add()
+            .newThreshold().withUnit(Unit.PERCENT_IMAX).withSide(ONE).withMin(-0.3).withMax(0.3).add()
+            .newThreshold().withUnit(Unit.PERCENT_IMAX).withSide(TWO).withMin(-0.3).withMax(0.3).add()
+            .withNominalVoltage(380.)
+            .withIMax(5000.)
+            .add();
+        RangeActionSensitivityProvider factorProvider = new RangeActionSensitivityProvider(crac.getRangeActions(), crac.getFlowCnecs(), Set.of(Unit.MEGAWATT, Unit.AMPERE));
+        AppliedRemedialActions appliedRemedialActions = new AppliedRemedialActions();
+        appliedRemedialActions.addAppliedRangeAction(crac.getState("Contingency FR1 FR3", curativeInstant), crac.getPstRangeAction("pst"), -3.1);
+
+        SystematicSensitivityResult result = SystematicSensitivityAdapter.runSensitivity(network, factorProvider, appliedRemedialActions, new SensitivityAnalysisParameters(), "MockSensi", crac.getOutageInstant());
+        assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE, result.getStatus());
+    }
+
+    @Test
+    void testSecondCatchInRunSensitivityWithAppliedRa() {
         Network network = NetworkImportsUtil.import12NodesNetwork();
         network.setName("Second_Run_Exception");
         Crac crac = CommonCracCreation.createWithPreventivePstRange(Set.of(ONE, TWO));

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityAdapterTest.java
@@ -162,4 +162,13 @@ class SystematicSensitivityAdapterTest {
         assertEquals(-5, result.getSensitivityOnFlow(crac.getRangeAction("pst"), crac.getFlowCnec("cnec2stateOutageContingency1"), ONE), DOUBLE_TOLERANCE);
         assertEquals(5.5, result.getSensitivityOnFlow(crac.getRangeAction("pst"), crac.getFlowCnec("cnec2stateOutageContingency1"), TWO), DOUBLE_TOLERANCE);
     }
+
+    @Test
+    void testCatchInRunSensitivity() {
+        Crac crac = CommonCracCreation.createWithPreventivePstRange(Set.of(ONE, TWO));
+        Instant outageInstant = crac.getInstant(OUTAGE_INSTANT_ID);
+        RangeActionSensitivityProvider factorProvider = new RangeActionSensitivityProvider(crac.getRangeActions(), crac.getFlowCnecs(), Set.of(Unit.MEGAWATT, Unit.AMPERE));
+        SystematicSensitivityResult result = SystematicSensitivityAdapter.runSensitivity(null, factorProvider, new SensitivityAnalysisParameters(), "MockSensi", outageInstant);
+        assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.FAILURE, result.getStatus());
+    }
 }

--- a/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResultTest.java
+++ b/sensitivity-analysis/src/test/java/com/powsybl/openrao/sensitivityanalysis/SystematicSensitivityResultTest.java
@@ -372,4 +372,21 @@ class SystematicSensitivityResultTest {
 
     }
 
+    @Test
+    void testCompleteDataWithFailingPerimeter() {
+        setUpWith12Nodes();
+        // When
+        SensitivityAnalysisResult sensitivityAnalysisResult = SensitivityAnalysis.find().run(network,
+            rangeActionSensitivityProvider.getAllFactors(network),
+            rangeActionSensitivityProvider.getContingencies(network),
+            new ArrayList<>(),
+            SensitivityAnalysisParameters.load());
+        SystematicSensitivityResult result = new SystematicSensitivityResult().completeData(sensitivityAnalysisResult, outageInstantOrder);
+        assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.SUCCESS, result.getStatus());
+
+        result.completeDataWithFailingPerimeter(outageInstantOrder, "Contingency FR1 FR3");
+        //  after computation failure on contingency
+        assertEquals(SystematicSensitivityResult.SensitivityComputationStatus.PARTIAL_FAILURE, result.getStatus());
+    }
+
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
During 2P sensitivity systematic analysis for states without RA the code crashes due to a powsybl error (com.powsybl.commons.PowsyblException: Load flow ended with status CONVERGED <-- load flow converge but outerloop is unstable) that is not properly caught. 

**What is the new behavior (if this is a feature change)?**
Instead of crashing, a SystematicSensitivityResult with status FAILURE is returned (same behavior as during 1P). Plus during sensitivity systematic analysis for states WITH RA, the error is also caught and handled (sensitivity status is set to PARTIAL_FAILURE due to failing perimeter).


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
