### PR TITLE
Classes generated by Jakarta implement interfaces

### DIFF
--- a/data/crac/crac-io/crac-io-cim/pom.xml
+++ b/data/crac/crac-io/crac-io-cim/pom.xml
@@ -26,6 +26,19 @@
             <plugin>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -72,6 +85,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/data/crac/crac-io/crac-io-csa-profiles/pom.xml
+++ b/data/crac/crac-io/crac-io-csa-profiles/pom.xml
@@ -26,6 +26,19 @@
             <plugin>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -87,6 +100,11 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
     </dependencies>
 

--- a/data/crac/crac-io/crac-io-csa-profiles/pom.xml
+++ b/data/crac/crac-io/crac-io-csa-profiles/pom.xml
@@ -21,28 +21,6 @@
     <description>CRAC creator implementation for CRAC specific to CSA profiles</description>
     <packaging>jar</packaging>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jvnet.jaxb</groupId>
-                <artifactId>jaxb-maven-plugin</artifactId>
-                <configuration>
-                    <extension>true</extension>
-                    <args>
-                        <arg>-Xinheritance</arg>
-                    </args>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.jvnet.jaxb</groupId>
-                            <artifactId>jaxb-plugins</artifactId>
-                            <version>${maven.jvnet.jaxb.version}</version>
-                        </plugin>
-                    </plugins>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -100,11 +78,6 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jvnet.jaxb</groupId>
-            <artifactId>jaxb-plugins-runtime</artifactId>
-            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
     </dependencies>
 

--- a/data/crac/crac-io/crac-io-cse/pom.xml
+++ b/data/crac/crac-io/crac-io-cse/pom.xml
@@ -29,6 +29,17 @@
                 <configuration>
                     <generatePackage>com.powsybl.openrao.data.crac.io.cse.xsd</generatePackage>
                     <schemaDirectory>src/main/resources/com/powsybl/openrao/data/crac/io/cse/xsd</schemaDirectory>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
                 </configuration>
             </plugin>
             <plugin>
@@ -68,6 +79,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/data/crac/crac-io/crac-io-fb-constraint/pom.xml
+++ b/data/crac/crac-io/crac-io-fb-constraint/pom.xml
@@ -26,6 +26,22 @@
             <plugin>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
+                <version>${maven.jvnet.jaxb.version}</version>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                        <arg>-Xcopyable</arg>
+                        <arg>-Xequals</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -63,6 +79,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/data/rao-result/rao-result-io/rao-result-cne/cne-exporter-commons/pom.xml
+++ b/data/rao-result/rao-result-io/rao-result-cne/cne-exporter-commons/pom.xml
@@ -26,6 +26,19 @@
             <plugin>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -64,6 +77,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/data/rao-result/rao-result-io/rao-result-cne/core-cne-exporter/pom.xml
+++ b/data/rao-result/rao-result-io/rao-result-cne/core-cne-exporter/pom.xml
@@ -26,6 +26,19 @@
             <plugin>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -83,6 +96,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/data/rao-result/rao-result-io/rao-result-cne/swe-cne-exporter/pom.xml
+++ b/data/rao-result/rao-result-io/rao-result-cne/swe-cne-exporter/pom.xml
@@ -26,6 +26,19 @@
             <plugin>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -88,6 +101,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/data/refprog/refprog-xml-importer/pom.xml
+++ b/data/refprog/refprog-xml-importer/pom.xml
@@ -19,6 +19,19 @@
             <plugin>
                 <groupId>org.jvnet.jaxb</groupId>
                 <artifactId>jaxb-maven-plugin</artifactId>
+                <configuration>
+                    <extension>true</extension>
+                    <args>
+                        <arg>-Xinheritance</arg>
+                    </args>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.jvnet.jaxb</groupId>
+                            <artifactId>jaxb-plugins</artifactId>
+                            <version>${maven.jvnet.jaxb.version}</version>
+                        </plugin>
+                    </plugins>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -39,6 +52,11 @@
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
             <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb</groupId>
+            <artifactId>jaxb-plugins-runtime</artifactId>
+            <version>${maven.jvnet.jaxb.version}</version>
         </dependency>
 
         <!-- Test dependencies -->


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
Since #1198, we lost the possibility for Jakarta-generated classes to implement interfaces like `Cloneable`. This PR fixes the problem.

This is a fix asked by the GridCapa team as they need to keep some beahviors inherited from the interfaces.



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
