### PR TITLE
Make MonitoringResult combine function thread safe

### DIFF
--- a/monitoring/src/main/java/com/powsybl/openrao/monitoring/results/MonitoringResult.java
+++ b/monitoring/src/main/java/com/powsybl/openrao/monitoring/results/MonitoringResult.java
@@ -81,7 +81,7 @@ public class MonitoringResult {
         return constraints;
     }
 
-    public void combine(MonitoringResult monitoringResult) {
+    public synchronized void combine(MonitoringResult monitoringResult) {
         Set<CnecResult> thisCnecResults = new HashSet<>(this.getCnecResults());
         Set<CnecResult> otherCnecResults = monitoringResult.getCnecResults();
         thisCnecResults.addAll(otherCnecResults);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
<!-- You can also link to an open issue here -->
When we call runMonitoring() several threads try to access and change the same monitoringResult object with the function combine() at the same time. For example, if thread1 call combine first but thread2 calls combine after but before the end of thread1 → leads to overwrite conflict.  


**What is the new behavior (if this is a feature change)?**
Make the function combine blocking by adding "synchronize" in the signature.



**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
