### PR TITLE
Delete mvn compiler version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
     <properties>
         <!-- Project properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
         <java.version>17</java.version>
 
         <!-- Sonar properties -->

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <properties>
         <!-- Project properties -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.source>17</maven.compiler.source>
         <java.version>17</java.version>
 
         <!-- Sonar properties -->


### PR DESCRIPTION

**What kind of change does this PR introduce?**
Bug fix : errors and warnings while trying to generate javadoc

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
No

**What is the current behavior?**
inherited maven compiler version from  powsybl parent



**What is the new behavior (if this is a feature change)?**
mvn clean package -Prelease OK


**Does this PR introduce a breaking change or deprecate an API?**
-No
