### PR TITLE
Add filter on version to avoid logging other project version

### DIFF
--- a/ra-optimisation/rao-api/src/main/java/com/powsybl/openrao/raoapi/InterTemporalRao.java
+++ b/ra-optimisation/rao-api/src/main/java/com/powsybl/openrao/raoapi/InterTemporalRao.java
@@ -50,7 +50,10 @@ public final class InterTemporalRao {
             Objects.requireNonNull(raoInput, "RAO input should not be null");
             Objects.requireNonNull(parameters, "parameters should not be null");
 
-            Version openRaoVersion = ServiceLoader.load(Version.class).findFirst().orElseThrow();
+            Version openRaoVersion = ServiceLoader.load(Version.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(version -> version.getRepositoryName().equals("open-rao"))
+                .findFirst().orElseThrow();
             BUSINESS_WARNS.warn("Running RAO using Open RAO version {} from git commit {}.", openRaoVersion.getMavenProjectVersion(), openRaoVersion.getGitVersion());
 
             return provider.run(raoInput, parameters).join();

--- a/ra-optimisation/rao-api/src/main/java/com/powsybl/openrao/raoapi/Rao.java
+++ b/ra-optimisation/rao-api/src/main/java/com/powsybl/openrao/raoapi/Rao.java
@@ -55,7 +55,10 @@ public final class Rao {
             Objects.requireNonNull(raoInput, "RAO input should not be null");
             Objects.requireNonNull(parameters, "parameters should not be null");
 
-            Version openRaoVersion = ServiceLoader.load(Version.class).findFirst().orElseThrow();
+            Version openRaoVersion = ServiceLoader.load(Version.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(version -> version.getRepositoryName().equals("open-rao"))
+                .findFirst().orElseThrow();
             BUSINESS_WARNS.warn("Running RAO using Open RAO version {} from git commit {}.", openRaoVersion.getMavenProjectVersion(), openRaoVersion.getGitVersion());
 
             return provider.run(raoInput, parameters, targetEndInstant);
@@ -77,7 +80,10 @@ public final class Rao {
             Objects.requireNonNull(raoInput, "RAO input should not be null");
             Objects.requireNonNull(parameters, "parameters should not be null");
 
-            Version openRaoVersion = ServiceLoader.load(Version.class).findFirst().orElseThrow();
+            Version openRaoVersion = ServiceLoader.load(Version.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .filter(version -> version.getRepositoryName().equals("open-rao"))
+                .findFirst().orElseThrow();
             BUSINESS_WARNS.warn("Running RAO using Open RAO version {} from git commit {}.", openRaoVersion.getMavenProjectVersion(), openRaoVersion.getGitVersion());
 
             return provider.run(raoInput, parameters, targetEndInstant).join();


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently we print info about the first Version the service loader finds. This lead to printing powsybl-diagram version when calling OpenRao via pypowsybl for instance.


**What is the new behavior (if this is a feature change)?**
We now filter the Versions on the repo name to make sure we print the correct one.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No