### PR TITLE
Replace old ContingencyElement.of by ContingencyElementFactory.create

### DIFF
--- a/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/crac/impl/ContingencyTest.java
+++ b/data/crac/crac-impl/src/test/java/com/powsybl/openrao/data/crac/impl/ContingencyTest.java
@@ -88,7 +88,7 @@ class ContingencyTest {
 
     @Test
     void testApplyOnGenerator() {
-        Contingency contingencyImpl = new Contingency("contingency", "contingency", Collections.singletonList(ContingencyElement.of(network.getIdentifiable("GENERATOR_FR_2"))));
+        Contingency contingencyImpl = new Contingency("contingency", "contingency", Collections.singletonList(ContingencyElementFactory.create(network.getIdentifiable("GENERATOR_FR_2"))));
         assertEquals(1, contingencyImpl.getElements().size());
         assertTrue(network.getGenerator("GENERATOR_FR_2").getTerminal().isConnected());
         contingencyImpl.isValid(network);
@@ -99,7 +99,7 @@ class ContingencyTest {
     @Test
     void testApplyOnDanglingLine() {
         network = Network.read("TestCase12NodesHvdc.uct", getClass().getResourceAsStream("/TestCase12NodesHvdc.uct"));
-        Contingency contingencyImpl = new Contingency("contingency", "contingency", Collections.singletonList(ContingencyElement.of(network.getIdentifiable("BBE2AA1  XLI_OB1B 1"))));
+        Contingency contingencyImpl = new Contingency("contingency", "contingency", Collections.singletonList(ContingencyElementFactory.create(network.getIdentifiable("BBE2AA1  XLI_OB1B 1"))));
         assertEquals(1, contingencyImpl.getElements().size());
         assertTrue(network.getDanglingLine("BBE2AA1  XLI_OB1B 1").getTerminal().isConnected());
         contingencyImpl.isValid(network);

--- a/data/crac/crac-io/crac-io-cim/src/main/java/com/powsybl/openrao/data/crac/io/cim/craccreator/CimContingencyCreator.java
+++ b/data/crac/crac-io/crac-io-cim/src/main/java/com/powsybl/openrao/data/crac/io/cim/craccreator/CimContingencyCreator.java
@@ -7,7 +7,7 @@
 
 package com.powsybl.openrao.data.crac.io.cim.craccreator;
 
-import com.powsybl.contingency.ContingencyElement;
+import com.powsybl.contingency.ContingencyElementFactory;
 import com.powsybl.contingency.ContingencyElementType;
 import com.powsybl.iidm.network.DanglingLine;
 import com.powsybl.iidm.network.TieLine;
@@ -81,7 +81,7 @@ public class CimContingencyCreator {
             Identifiable<?> networkElement = getNetworkElementInNetwork(registeredResource.getMRID().getValue());
             if (networkElement != null) {
                 String networkElementId = networkElement.getId();
-                ContingencyElementType contingencyElementType = ContingencyElement.of(networkElement).getType();
+                ContingencyElementType contingencyElementType = ContingencyElementFactory.create(networkElement).getType();
                 contingencyAdder.withContingencyElement(networkElementId, contingencyElementType);
                 anyRegisteredResourceOk = true;
             } else {

--- a/data/crac/crac-io/crac-io-commons/src/main/java/com/powsybl/openrao/data/crac/io/commons/ucte/UcteContingencyElementHelper.java
+++ b/data/crac/crac-io/crac-io-commons/src/main/java/com/powsybl/openrao/data/crac/io/commons/ucte/UcteContingencyElementHelper.java
@@ -7,7 +7,7 @@
 
 package com.powsybl.openrao.data.crac.io.commons.ucte;
 
-import com.powsybl.contingency.ContingencyElement;
+import com.powsybl.contingency.ContingencyElementFactory;
 import com.powsybl.contingency.ContingencyElementType;
 import com.powsybl.openrao.data.crac.io.commons.ElementHelper;
 import com.powsybl.iidm.network.Identifiable;
@@ -95,7 +95,7 @@ public class UcteContingencyElementHelper extends AbstractUcteConnectableHelper 
         Identifiable<?> networkElement = ucteMatchingResult.getIidmIdentifiable();
 
         this.connectableIdInNetwork = networkElement.getId();
-        this.connectableContingencyTypeInNetwork = ContingencyElement.of(networkElement).getType();
+        this.connectableContingencyTypeInNetwork = ContingencyElementFactory.create(networkElement).getType();
 
     }
 }

--- a/data/crac/crac-io/crac-io-fb-constraint/src/main/java/com/powsybl/openrao/data/crac/io/fbconstraint/OutageReader.java
+++ b/data/crac/crac-io/crac-io-fb-constraint/src/main/java/com/powsybl/openrao/data/crac/io/fbconstraint/OutageReader.java
@@ -6,7 +6,7 @@
  */
 package com.powsybl.openrao.data.crac.io.fbconstraint;
 
-import com.powsybl.contingency.ContingencyElement;
+import com.powsybl.contingency.ContingencyElementFactory;
 import com.powsybl.contingency.ContingencyElementType;
 import com.powsybl.openrao.data.crac.api.ContingencyAdder;
 import com.powsybl.openrao.data.crac.api.Crac;
@@ -91,8 +91,8 @@ class OutageReader {
                     this.isOutageValid = false;
                     this.invalidOutageReason = String.format("one of the two Xnodes of outage %s was not found in the network: %s, %s", outage.getId(), hvdcVH.getFrom(), hvdcVH.getTo());
                 } else {
-                    outageElementIdsAndContingencyType.put(dl1.getId(), ContingencyElement.of(dl1).getType());
-                    outageElementIdsAndContingencyType.put(dl2.getId(), ContingencyElement.of(dl2).getType());
+                    outageElementIdsAndContingencyType.put(dl1.getId(), ContingencyElementFactory.create(dl1).getType());
+                    outageElementIdsAndContingencyType.put(dl2.getId(), ContingencyElementFactory.create(dl2).getType());
                 }
             });
         }

--- a/data/crac/crac-io/crac-io-json/src/main/java/com/powsybl/openrao/data/crac/io/json/deserializers/ContingencyArrayDeserializer.java
+++ b/data/crac/crac-io/crac-io-json/src/main/java/com/powsybl/openrao/data/crac/io/json/deserializers/ContingencyArrayDeserializer.java
@@ -7,7 +7,7 @@
 
 package com.powsybl.openrao.data.crac.io.json.deserializers;
 
-import com.powsybl.contingency.ContingencyElement;
+import com.powsybl.contingency.ContingencyElementFactory;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.openrao.commons.OpenRaoException;
@@ -51,7 +51,7 @@ final class ContingencyArrayDeserializer {
                                     + " does not exist in network " + network.getId()
                                     + ", so it does not have type information and can not be converted to a contingency element.");
                             }
-                            adder.withContingencyElement(neId, ContingencyElement.of(ne).getType());
+                            adder.withContingencyElement(neId, ContingencyElementFactory.create(ne).getType());
                         }
                         break;
                     default:

--- a/data/crac/crac-io/crac-io-nc/src/main/java/com/powsybl/openrao/data/crac/io/nc/craccreator/contingency/NcContingencyCreator.java
+++ b/data/crac/crac-io/crac-io-nc/src/main/java/com/powsybl/openrao/data/crac/io/nc/craccreator/contingency/NcContingencyCreator.java
@@ -7,7 +7,7 @@
 
 package com.powsybl.openrao.data.crac.io.nc.craccreator.contingency;
 
-import com.powsybl.contingency.ContingencyElement;
+import com.powsybl.contingency.ContingencyElementFactory;
 import com.powsybl.contingency.ContingencyElementType;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.openrao.data.crac.api.ContingencyAdder;
@@ -100,7 +100,7 @@ public class NcContingencyCreator {
                 if (networkElement == null) {
                     missingNetworkElements.add(nativeContingencyEquipment.equipment());
                 } else {
-                    ContingencyElementType contingencyElementType = ContingencyElement.of(networkElement).getType();
+                    ContingencyElementType contingencyElementType = ContingencyElementFactory.create(networkElement).getType();
                     contingencyAdder.withContingencyElement(networkElement.getId(), contingencyElementType);
                 }
             }

--- a/data/crac/crac-util/src/test/java/com/powsybl/openrao/data/crac/util/CracValidatorTest.java
+++ b/data/crac/crac-util/src/test/java/com/powsybl/openrao/data/crac/util/CracValidatorTest.java
@@ -7,7 +7,7 @@
 
 package com.powsybl.openrao.data.crac.util;
 
-import com.powsybl.contingency.ContingencyElement;
+import com.powsybl.contingency.ContingencyElementFactory;
 import com.powsybl.contingency.ContingencyElementType;
 import com.powsybl.openrao.commons.Unit;
 import com.powsybl.openrao.data.crac.api.Crac;
@@ -40,7 +40,7 @@ class CracValidatorTest {
     private Instant outageInstant;
 
     private ContingencyElementType getContingencyType(String id) {
-        return ContingencyElement.of(network.getIdentifiable(id)).getType();
+        return ContingencyElementFactory.create(network.getIdentifiable(id)).getType();
     }
 
     @BeforeEach

--- a/docs/input-data/crac/json.md
+++ b/docs/input-data/crac/json.md
@@ -152,7 +152,7 @@ crac.newContingency()
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; 🔴 **contingency element type**: type of element in the network. Currently, PowSyBl handles: 
 GENERATOR, STATIC_VAR_COMPENSATOR, SHUNT_COMPENSATOR, BRANCH, HVDC_LINE, BUSBAR_SECTION, DANGLING_LINE, LINE, TWO_WINDINGS_TRANSFORMER, 
 THREE_WINDINGS_TRANSFORMER, LOAD, SWITCH, BATTERY, BUS, TIE_LINE. The contingency elements type can be retrieved from the PowSyBl Network using the network element id, using: 
-`ContingencyElement.of(network.getIdentifiable(id)).getType()`.  
+`ContingencyElementFactory.create(network.getIdentifiable(id)).getType()`.  
 :::
 ::::
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Adaptation to dependency breaking change


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`ContingencyElement`s are created via `ContingencyElement.of(Identifiable<?> identifiable)`.
But powsybl/powsybl-core#3421 replaces this method by `ContingencyElementFactory.create(Identifiable<?> identifiable)`.


**What is the new behavior (if this is a feature change)?**
`ContingencyElement`s are created via `ContingencyElementFactory.create(Identifiable<?> identifiable)`.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
