### PR TITLE
Fix BestTapFinderTest

### DIFF
--- a/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/linearoptimisation/algorithms/BestTapFinderTest.java
+++ b/ra-optimisation/search-tree-rao/src/test/java/com/powsybl/openrao/searchtreerao/linearoptimisation/algorithms/BestTapFinderTest.java
@@ -19,7 +19,9 @@ import com.powsybl.openrao.searchtreerao.commons.optimizationperimeters.Optimiza
 import com.powsybl.openrao.searchtreerao.result.api.*;
 import com.powsybl.openrao.searchtreerao.result.impl.RangeActionActivationResultImpl;
 import com.powsybl.openrao.searchtreerao.result.impl.RangeActionSetpointResultImpl;
+import com.powsybl.iidm.network.DefaultMessageHeader;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.Validable;
 import com.powsybl.iidm.network.ValidationException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,13 +90,14 @@ class BestTapFinderTest {
     }
 
     private void mockPstRangeAction(PstRangeAction pstRangeAction) {
-        when(pstRangeAction.convertTapToAngle(-3)).thenThrow(new ValidationException(() -> "header", "Out of bound"));
+        Validable.MessageHeader messageHeader = new DefaultMessageHeader("PST", "1");
+        when(pstRangeAction.convertTapToAngle(-3)).thenThrow(new ValidationException(() -> messageHeader, "Out of bound"));
         when(pstRangeAction.convertTapToAngle(-2)).thenReturn(-2.5);
         when(pstRangeAction.convertTapToAngle(-1)).thenReturn(-0.75);
         when(pstRangeAction.convertTapToAngle(0)).thenReturn(0.);
         when(pstRangeAction.convertTapToAngle(1)).thenReturn(0.75);
         when(pstRangeAction.convertTapToAngle(2)).thenReturn(2.5);
-        when(pstRangeAction.convertTapToAngle(3)).thenThrow(new ValidationException(() -> "header", "Out of bound"));
+        when(pstRangeAction.convertTapToAngle(3)).thenThrow(new ValidationException(() -> messageHeader, "Out of bound"));
     }
 
     private void setClosestTapPosition(PstRangeAction pstRangeAction, double setPoint, int tapPosition) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Compilation fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
`BestTapFinderTest` mocks a `Validable.getMessageHeader()` with a `String` as result type. But starting from powsybl-core 6.8.0, the result type is a `Validable.MessageHeader`. Therefore, the compilation fails.


**What is the new behavior (if this is a feature change)?**
`BestTapFinderTest` mocks a `Validable.getMessageHeader()` with a `Validable.MessageHeader` as result type.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
