### PR TITLE
Hard set default to SearchTreeRao

### DIFF
--- a/ra-optimisation/rao-api/src/main/java/com/powsybl/openrao/raoapi/Rao.java
+++ b/ra-optimisation/rao-api/src/main/java/com/powsybl/openrao/raoapi/Rao.java
@@ -126,7 +126,7 @@ public final class Rao {
      * @return a runner for default RAO implementation
      */
     public static Runner find() {
-        return find(null);
+        return find("SearchTreeRao");
     }
 
     /**


### PR DESCRIPTION

**What kind of change does this PR introduce?**
Hard set default rao provider to SearchTreeRao. Now that FastRao is available, 2 rao providers could be used.
